### PR TITLE
#180 REFACTOR only referenece terrateam server, clean up how it works

### DIFF
--- a/docs/src/content/docs/configuration-reference/hooks.mdx
+++ b/docs/src/content/docs/configuration-reference/hooks.mdx
@@ -51,7 +51,7 @@ The `run` hook type executes a command from the directory that Terrateam is oper
 |-----|------|-------------|
 | cmd | List | Command to run. |
 | run_on | String | Run the command on step success, failure, or always. Default is success. |
-| capture_output | Boolean | When set to true, command output is included in the GitHub pull request comment on a failure. Sensitive data is not masked. Be aware, this data is sent back to the Terrateam backend for processing. Default is false. |
+| capture_output | Boolean | When set to true, command output is included in the GitHub pull request comment on a failure. Sensitive data is not masked. Be aware, this data is sent back to the Terrateam server for processing. Default is false. |
 
 ### `oidc`
 The `oidc` hook type can be used to initiate an OIDC connection to a cloud provider.

--- a/docs/src/content/docs/configuration-reference/storage.mdx
+++ b/docs/src/content/docs/configuration-reference/storage.mdx
@@ -3,7 +3,7 @@ title: storage
 description: The storage configuration reference
 ---
 
-The `storage` configuration allows users to define where plan files are stored, providing control over security and access. By default, plan files are stored on the Terrateam backend, but alternative methods are supported.
+The `storage` configuration allows users to define where plan files are stored, providing control over security and access. By default, plan files are stored on the Terrateam server, but alternative methods are supported.
 
 ## Default Configuration
 ```yaml

--- a/docs/src/content/docs/configuration-reference/workflows.mdx
+++ b/docs/src/content/docs/configuration-reference/workflows.mdx
@@ -89,7 +89,7 @@ Custom commands can be run using the `run` step type.
 |-----|------|-------------|
 | cmd | List | Command to run from the directory that Terrateam is operating against. |
 | run_on | String | Run the command on step `success`, `failure`, or `always`. Default is `success`. |
-| capture_output | Boolean | When set to `true`, command output is included in the GitHub pull request comment on a failure. Sensitive data is not masked. Be aware, this data is sent back to the Terrateam backend for processing. Default is `false`. |
+| capture_output | Boolean | When set to `true`, command output is included in the GitHub pull request comment on a failure. Sensitive data is not masked. Be aware, this data is sent back to the Terrateam server for processing. Default is `false`. |
 | env | Object | Environment variables to set for this execution. Object keys are environment variable names and the value is a string. |
 
 ### OIDC

--- a/docs/src/content/docs/how-it-works.mdx
+++ b/docs/src/content/docs/how-it-works.mdx
@@ -11,11 +11,11 @@ Terrateam is a powerful GitHub application that seamlessly integrates with your 
 ## Architecture Overview
 Terrateam consists of two main components:
 <CardGrid>
-  <Card title="Terrateam Backend" icon="server">
-    The backend receives GitHub events and makes decisions based on the event payload. It orchestrates the execution of Terraform operations and manages the state of your infrastructure.
+  <Card title="Terrateam Server" icon="server">
+    The server receives GitHub events and makes decisions based on the event payload. It orchestrates the execution of Terraform operations and manages the state of your infrastructure.
   </Card>
   <Card title="Terrateam Runner" icon="running">
-    The runner is responsible for executing the Terraform jobs created by the backend. It interacts with your GitHub repository, performs the necessary Terraform commands, and reports the results back to the backend.
+    The runner is responsible for executing the Terraform jobs created by the server. It interacts with your GitHub repository, performs the necessary Terraform commands, and reports the results back to the server.
   </Card>
 </CardGrid>
 
@@ -24,15 +24,15 @@ Here's a high-level overview of how Terrateam works:
 <Steps>
 1. Event Trigger
 
-   A user performs an action on GitHub, such as opening a pull request, updating it, or commenting on it. This action triggers an event that is sent to the Terrateam backend.
+   A user performs an action on GitHub, such as opening a pull request, updating it, or commenting on it. This action triggers an event that is sent to the Terrateam server.
 
 1. Event Evaluation
 
-   The Terrateam backend evaluates the received event to determine if a Terraform operation needs to be executed. It analyzes the changes in the pull request and decides whether to trigger a plan or apply operation.
+   The Terrateam server evaluates the received event to determine if a Terraform operation needs to be executed. It analyzes the changes in the pull request and decides whether to trigger a plan or apply operation.
 
 1. Workflow Dispatch
 
-   If the backend determines that a Terraform operation is required, it dispatches a GitHub Actions workflow to the Terrateam runner. The workflow contains the necessary information and instructions for executing the Terraform commands.
+   If the server determines that a Terraform operation is required, it dispatches a GitHub Actions workflow to the Terrateam runner. The workflow contains the necessary information and instructions for executing the Terraform commands.
 
 1. Terraform Execution
 
@@ -40,11 +40,11 @@ Here's a high-level overview of how Terrateam works:
 
 1. Result Reporting
 
-   Once the Terraform execution is complete, the Terrateam runner collects the results and sends them back to the Terrateam backend. The results include the output of the Terraform commands, any changes made to the infrastructure, and the overall status of the operation.
+   Once the Terraform execution is complete, the Terrateam runner collects the results and sends them back to the Terrateam server. The results include the output of the Terraform commands, any changes made to the infrastructure, and the overall status of the operation.
 
 1. Feedback and Notifications
 
-   The Terrateam backend processes the received results and provides feedback to the user. It adds comments to the pull request with the Terraform plan output, updates the status checks, and notifies the relevant stakeholders about the outcome of the operation.
+   The Terrateam server processes the received results and provides feedback to the user. It adds comments to the pull request with the Terraform plan output, updates the status checks, and notifies the relevant stakeholders about the outcome of the operation.
 
 </Steps>
 
@@ -64,22 +64,6 @@ Terrateam offers several key features that enhance your Terraform workflow:
     Terrateam allows you to customize your Terraform workflows using a configuration file. You can define custom plan and apply steps, set up notifications, and integrate with other tools and services to tailor Terrateam to your specific needs.
   </Card>
 </CardGrid>
-
-## Architecture Diagram
-Here's a visual representation of Terrateam's architecture:
-
-![Architecture Diagram](../../assets/how-it-works.png)
-
-In this diagram:
-<Steps>
-1. The GitHub pull request triggers an event (e.g., open, close, comment) that is sent to the Terrateam backend.
-
-1. The Terrateam backend evaluates the event and dispatches a workflow to GitHub Actions if a Terraform operation is required.
-
-1. GitHub Actions (the Terrateam runner) executes the Terraform commands and sends the results back to the Terrateam backend.
-
-1. The Terrateam backend processes the results and provides feedback and notifications to the GitHub pull request.
-</Steps>
 
 ## Hierarchy Of Repositories
 Terrateam organizes your Terraform code using the following hierarchy:

--- a/docs/src/content/docs/integrations/plan-file-storage.mdx
+++ b/docs/src/content/docs/integrations/plan-file-storage.mdx
@@ -27,7 +27,7 @@ In this example, we set the `method` to `s3` to indicate that we want to store p
 Terrateam supports several storage methods for plan files:
 
 ##### `terrateam` (default)
-Plan files are stored within the Terrateam backend. This is the default behavior and requires no additional configuration.
+Plan files are stored within the Terrateam server. This is the default behavior and requires no additional configuration.
 
 ##### `s3`
 Plan files are stored in an AWS S3 bucket. You need to provide the `bucket` and `region` in your configuration.


### PR DESCRIPTION
## Description

Only reference the Terrateam server as the Terrateam server (not backend). Clean up some redundancy in the how it works section.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Other (explain):

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/terrateamio/terrateam/blob/main/CONTRIBUTING.md)
- [x] The pull request title follows this format:
      `ISSUE_NUMBER ACTION_TYPE Short description` (e.g., `123 ADD Feature description`)
- [x] I have added tests and documentation (if applicable)
- [x] My changes generate no new warnings/errors and do not break existing functionality

## Additional context (optional)

<!-- Add any additional context here, e.g., screenshots, dependencies, etc. -->
