### PR TITLE
#458 FIX collapse self-hosted docs by default

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -102,6 +102,7 @@ export default defineConfig({
         },
         {
           label: "Self-Hosted",
+          collapsed: true,
           items: [
             { label: "Instructions", link: "/self-hosted/instructions" },
             { label: "Best Practices", link: "/self-hosted/best-practices" },


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes and the issue it fixes. -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Other (explain):

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/terrateamio/terrateam/blob/main/CONTRIBUTING.md)
- [x] The pull request title follows this format:
      `ISSUE_NUMBER ACTION_TYPE Short description` (e.g., `123 ADD Feature description`)
- [x] I have added tests and documentation (if applicable)
- [x] My changes generate no new warnings/errors and do not break existing functionality

## Additional context (optional)

<!-- Add any additional context here, e.g., screenshots, dependencies, etc. -->
