### PR TITLE
#587 REFACTOR enable analytics + saas subscription screen

### DIFF
--- a/code/src/iris/src/lib/utils/environment.ts
+++ b/code/src/iris/src/lib/utils/environment.ts
@@ -15,8 +15,8 @@ export function isAnalyticsEnabled(): boolean {
     return enabled;
   }
   
-  // Default to disabled for safety
-  return false;
+  // Default to enabled
+  return true;
 }
 
 /**
@@ -32,8 +32,8 @@ export function getSubscriptionMode(): SubscriptionMode {
     }
   }
   
-  // Default to OSS mode (shows self-hosted/enterprise contact info)
-  return 'oss';
+  // Default to SaaS mode (shows SaaS billing and payment options)
+  return 'saas';
 }
 
 /**


### PR DESCRIPTION
## Description

Temporarily enable analytics and saas subscription screen by default. Will revert once I have the code change to drive these by env vars.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (explain):

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/terrateamio/terrateam/blob/main/CONTRIBUTING.md)
- [x] The pull request title follows this format:
      `ISSUE_NUMBER ACTION_TYPE Short description` (e.g., `123 ADD Feature description`)
- [x] I have added tests and documentation (if applicable)
- [x] My changes generate no new warnings/errors and do not break existing functionality

## Additional context (optional)

<!-- Add any additional context here, e.g., screenshots, dependencies, etc. -->
