### PR TITLE
#655 REFACTOR improve when modified docs for all levels

### DIFF
--- a/docs/src/content/docs/configuration-reference/dirs.mdx
+++ b/docs/src/content/docs/configuration-reference/dirs.mdx
@@ -63,25 +63,62 @@ Each directory automatically receives a `dir:<name>` tag, where `<name>` is the 
 Each workspace automatically receives a `workspace:<name>` tag, where `<name>` is the name of the workspace.
 
 ### Workspaces
-The `workspaces` configuration is an object where the object key is the name of the workspace and the value is its configuration. Unique custom tags can be created against a directory and workspace combination.
+The `workspaces` configuration is an object where the object key is the name of the workspace and the value is its configuration. Each workspace can have its own:
+- Custom tags for targeting specific workspace operations
+- `when_modified` configuration to override directory or global settings
+
 | Key | Type | Description |
 | --- | --- | --- |
 | workspaces | object | Workspace configuration. |
+| workspaces.\<name\>.tags | list | List of tags to assign to the workspace. |
+| workspaces.\<name\>.when_modified | object | Workspace-specific when_modified configuration. |
+
+#### Example
+```yaml
+dirs:
+  infrastructure:
+    tags: [aws]  # Directory-level tag
+    workspaces:
+      production:
+        tags: [critical, prod]  # Workspace-specific tags
+        when_modified:
+          file_patterns: ["${DIR}/*.tf", "shared/*.tf", "modules/*.tf"]
+          autoplan: true
+          autoapply: true
+      staging:
+        tags: [non-critical, staging]  # Different tags for staging
+        when_modified:
+          file_patterns: ["${DIR}/*.tf", "shared/*.tf"]  
+          autoplan: true
+          autoapply: false  # No auto-apply for staging
+```
+
+This example demonstrates:
+- Directory-level tags (`aws`) apply to all workspaces
+- Each workspace has its own tags (`critical`/`prod` vs `non-critical`/`staging`)
+- Each workspace has custom `when_modified` rules (production monitors more files and has auto-apply enabled)
 
 ### When Modified
-The `when_modified` configuration can be set in the `dirs` directive to override the [global `when_modified` configuration](/configuration-reference/when-modified).
+The `when_modified` configuration can be set at multiple levels within the `dirs` directive:
+
+1. **Directory level**: `dirs.<directory>.when_modified` - Overrides global settings for all workspaces in that directory
+2. **Workspace level**: `dirs.<directory>.workspaces.<workspace>.when_modified` - Overrides both global and directory-level settings for a specific workspace
+
 | Key | Type | Description |
 | --- | --- | --- |
 | when_modified | object | Configuration to override when to match pull request file changes with autoplan and autoapply. |
 
-- The `when_modified` configuration syntax is identical to the top-level `when_modified`.
-- The `when_modified` configuration defaults to the top-level `when_modified`.
-- The `when_modified` keys can be individually overridden in `dirs`.
-- The `file_patterns` default value is set to the path of the directory specified in the `dirs` object.
-- The `file_patterns` list is always relative to the root of the repository.
-- The `${DIR}` variable specified in `file_patterns` is always relative to the root of the repository. The internal `${DIR}` variable can be used to specify the directory that Terrateam is working against.
+#### Configuration Hierarchy
+- The `when_modified` configuration syntax is identical across all levels (global, directory, and workspace)
+- More specific configurations override broader ones: workspace > directory > global
+- Each level inherits from the level above it, with individual keys that can be overridden
+- The `file_patterns` default value is set to the path of the directory specified in the `dirs` object
+- The `file_patterns` list is always relative to the root of the repository
+- The `${DIR}` variable specified in `file_patterns` is always relative to the root of the repository and can be used to specify the directory that Terrateam is working against
 
-#### Example
+#### Examples
+
+##### Directory-Level Configuration
 ```yaml
 dirs:
   foobar:
@@ -89,7 +126,26 @@ dirs:
       file_patterns: ["${DIR}/*.tf"]
 ```
 
-The example above triggers a Terrateam plan operation when `foobar/*.tf` is modified in a pull request.
+This triggers a Terrateam plan operation when `foobar/*.tf` is modified in a pull request.
+
+##### Workspace-Level Configuration
+```yaml
+dirs:
+  foobar:
+    workspaces:
+      production:
+        when_modified:
+          file_patterns: ["${DIR}/*.tf", "shared/*.tf"]
+          autoplan: true
+          autoapply: true
+      staging:
+        when_modified:
+          file_patterns: ["${DIR}/*.tf"]
+          autoplan: true
+          autoapply: false
+```
+
+This example shows different `when_modified` configurations for production and staging workspaces within the same directory. The production workspace will autoplan and autoapply when either directory-specific or shared files change, while staging will only autoplan (not autoapply).
 
 ## Globs
 The `dirs` directive supports glob patterns, which can be useful for repositories with a lot of directories that match a pattern with a similar configuration.

--- a/docs/src/content/docs/configuration-reference/dirs.mdx
+++ b/docs/src/content/docs/configuration-reference/dirs.mdx
@@ -96,7 +96,7 @@ dirs:
 This example demonstrates:
 - Directory-level tags (`aws`) apply to all workspaces
 - Each workspace has its own tags (`critical`/`prod` vs `non-critical`/`staging`)
-- Each workspace has custom `when_modified` rules (production monitors more files and has auto-apply enabled)
+- Each workspace has custom `when_modified` rules (production is triggered by more file patterns and has auto-apply enabled)
 
 ### When Modified
 The `when_modified` configuration can be set at multiple levels within the `dirs` directive:

--- a/docs/src/content/docs/configuration-reference/dirs.mdx
+++ b/docs/src/content/docs/configuration-reference/dirs.mdx
@@ -101,8 +101,8 @@ This example demonstrates:
 ### When Modified
 The `when_modified` configuration can be set at multiple levels within the `dirs` directive:
 
-1. **Directory level**: `dirs.<directory>.when_modified` - Overrides global settings for all workspaces in that directory
-2. **Workspace level**: `dirs.<directory>.workspaces.<workspace>.when_modified` - Overrides both global and directory-level settings for a specific workspace
+1. **Directory level**: `dirs.<directory>.when_modified` - Applies to ALL workspaces within that directory, overriding the global `when_modified` settings
+2. **Workspace level**: `dirs.<directory>.workspaces.<workspace>.when_modified` - The most specific level, applies only to that individual workspace, overriding both global and directory-level settings
 
 | Key | Type | Description |
 | --- | --- | --- |

--- a/docs/src/content/docs/configuration-reference/dirs.mdx
+++ b/docs/src/content/docs/configuration-reference/dirs.mdx
@@ -111,7 +111,7 @@ The `when_modified` configuration can be set at multiple levels within the `dirs
 #### Configuration Hierarchy
 - The `when_modified` configuration syntax is identical across all levels (global, directory, and workspace)
 - More specific configurations override broader ones: workspace > directory > global
-- Each level inherits from the level above it, with individual keys that can be overridden
+- Individual keys can be overridden at each level (e.g., you can set only `autoapply: true` at the workspace level while other settings come from higher levels)
 - The `file_patterns` default value is set to the path of the directory specified in the `dirs` object
 - The `file_patterns` list is always relative to the root of the repository
 - The `${DIR}` variable specified in `file_patterns` is always relative to the root of the repository and can be used to specify the directory that Terrateam is working against

--- a/docs/src/content/docs/configuration-reference/when-modified.mdx
+++ b/docs/src/content/docs/configuration-reference/when-modified.mdx
@@ -5,6 +5,16 @@ description: The when_modified configuration reference
 
 The `when_modified` configuration allows you to configure autoplan and autoapply operations based on pull request file changes. This enables you to automatically trigger plan and apply operations when specific files are modified in your repository.
 
+## Configuration Levels
+
+The `when_modified` configuration can be set at three different levels, all using the same syntax:
+
+1. **Global level** - Applied to all directories unless overridden
+2. **Directory level** - Set under `dirs.<directory>.when_modified` to override global settings for a specific directory
+3. **Workspace level** - Set under `dirs.<directory>.workspaces.<workspace>.when_modified` to override settings for a specific workspace
+
+All three levels support the exact same configuration options. More specific configurations override broader ones (workspace > directory > global).
+
 ## Default Configuration
 ```yaml
 when_modified:
@@ -43,9 +53,44 @@ The `depends_on` key allows you to specify dependencies on other directories wit
 - Layered Operations: Supports multi-layered operations, where each layer depends on the successful apply of the previous one.
 - Dependency Management: Automatically triggers plan and apply operations based on changes in the lowest layer, and cascades through dependent layers.
 
-While it's technically possible to specify dependencies using the `depends_on` key at a global level, it is recommended to define them within the `dirs.when_modified` configuration for better granularity and control. The `dirs.when_modified` configuration supports the same keys as the global `when_modified` configuration.
+While the `depends_on` key can be specified in the top-level `when_modified` configuration (which would make ALL directories depend on the specified directories), it is strongly recommended to define dependencies at the directory or workspace level for better control. Use `dirs.<directory>.when_modified.depends_on` or `dirs.<directory>.workspaces.<workspace>.when_modified.depends_on` instead.
 
-## Examples
+## Configuration Examples
+
+### Same Configuration at Different Levels
+
+The following three configurations achieve the same result for the `production` directory/workspace:
+
+#### 1. Global Level Configuration
+```yaml
+when_modified:
+  file_patterns: ["**/*.tf", "**/*.tfvars"]
+  autoplan: true
+  autoapply: false
+```
+
+#### 2. Directory Level Configuration
+```yaml
+dirs:
+  production:
+    when_modified:
+      file_patterns: ["**/*.tf", "**/*.tfvars"]
+      autoplan: true
+      autoapply: false
+```
+
+#### 3. Workspace Level Configuration
+```yaml
+dirs:
+  production:
+    workspaces:
+      default:
+        when_modified:
+          file_patterns: ["**/*.tf", "**/*.tfvars"]
+          autoplan: true
+          autoapply: false
+```
+
 ### Auto-Plan on Terraform File Changes
 ```yaml
 when_modified:

--- a/docs/src/content/docs/configuration-reference/when-modified.mdx
+++ b/docs/src/content/docs/configuration-reference/when-modified.mdx
@@ -59,7 +59,7 @@ While the `depends_on` key can be specified in the top-level `when_modified` con
 
 ### Same Configuration at Different Levels
 
-The following three configurations achieve the same result for the `production` directory/workspace:
+The following three configurations achieve the same result for the `production` directory:
 
 #### 1. Global Level Configuration
 ```yaml

--- a/docs/src/content/docs/configuration-reference/when-modified.mdx
+++ b/docs/src/content/docs/configuration-reference/when-modified.mdx
@@ -18,7 +18,7 @@ All three levels support the exact same configuration options. More specific con
 ## Default Configuration
 ```yaml
 when_modified:
-  file_patterns: ["**/*.tf", "**/*.tfvars"]
+  file_patterns: ["${DIR}/*.tf", "${DIR}/*.tfvars"]
   autoplan: true
   autoplan_draft_pr: true
   autoapply: false
@@ -28,7 +28,7 @@ when_modified:
 ## Keys
 | Key                  | Type    | Description                                                                                       |
 |----------------------|---------|---------------------------------------------------------------------------------------------------|
-| file_patterns        | List    | List of file globs to identify changes in a directory. Always relative to the root of the repository. Prefix with `!` to exclude a file glob. Default is `["**/*.tf", "**/*.tfvars"]`. |
+| file_patterns        | List    | List of file globs to identify changes in a directory. Always relative to the root of the repository. Prefix with `!` to exclude a file glob. Default is `["${DIR}/*.tf", "${DIR}/*.tfvars"]`. |
 | autoplan             | Boolean | Automatically run a plan operation on a new pull request or an update on an existing one. Default is true. |
 | autoplan_draft_pr    | Boolean | Automatically run a plan operation on a new draft pull request or an update on an existing one. Default is true. |
 | autoapply            | Boolean | Automatically run an apply operation after merging a pull request. Default is false. |
@@ -64,7 +64,7 @@ The following three configurations achieve the same result for the `production` 
 #### 1. Global Level Configuration
 ```yaml
 when_modified:
-  file_patterns: ["**/*.tf", "**/*.tfvars"]
+  file_patterns: ["${DIR}/*.tf", "${DIR}/*.tfvars"]
   autoplan: true
   autoapply: false
 ```
@@ -74,7 +74,7 @@ when_modified:
 dirs:
   production:
     when_modified:
-      file_patterns: ["**/*.tf", "**/*.tfvars"]
+      file_patterns: ["${DIR}/*.tf", "${DIR}/*.tfvars"]
       autoplan: true
       autoapply: false
 ```
@@ -86,7 +86,7 @@ dirs:
     workspaces:
       default:
         when_modified:
-          file_patterns: ["**/*.tf", "**/*.tfvars"]
+          file_patterns: ["${DIR}/*.tf", "${DIR}/*.tfvars"]
           autoplan: true
           autoapply: false
 ```
@@ -94,7 +94,7 @@ dirs:
 ### Auto-Plan on Terraform File Changes
 ```yaml
 when_modified:
-  file_patterns: ["**/*.tf"]
+  file_patterns: ["${DIR}/*.tf"]
   autoplan: true
   autoplan_draft_pr: false
   autoapply: false
@@ -104,7 +104,7 @@ This configuration triggers a plan operation automatically when any `.tf` file i
 ### Auto-Plan and Auto-Apply on Terraform and tfvars File Changes
 ```yaml
 when_modified:
-  file_patterns: ["**/*.tf", "**/*.tfvars"]
+  file_patterns: ["${DIR}/*.tf", "${DIR}/*.tfvars"]
   autoplan: true
   autoplan_draft_pr: true
   autoapply: true
@@ -114,7 +114,7 @@ This configuration triggers plan operations automatically on changes to `.tf` or
 ### Exclude Certain Files from Triggering Auto-Plan
 ```yaml
 when_modified:
-  file_patterns: ["**/*.tf", "!**/modules/**/*.tf"]
+  file_patterns: ["${DIR}/*.tf", "!**/modules/**/*.tf"]
   autoplan: true
   autoplan_draft_pr: true
   autoapply: false
@@ -135,15 +135,15 @@ This configuration triggers a plan operation for the `database` directory if cha
 dirs:
   network:
     when_modified:
-      file_patterns: ["**/*.tf"]
+      file_patterns: ["${DIR}/*.tf"]
   database:
     when_modified:
       depends_on: 'dir:network'
-      file_patterns: ["**/*.tf"]
+      file_patterns: ["${DIR}/*.tf"]
   application:
     when_modified:
       depends_on: 'dir:database'
-      file_patterns: ["**/*.tf"]
+      file_patterns: ["${DIR}/*.tf"]
 ```
 This configuration triggers a plan operation for the `network` layer if changes are detected. If the apply for the `network` layer is successful, a plan operation will be triggered for the `database` layer, which depends on `network`. If the `database` layer's apply is successful, the process continues with a plan operation for the `application` layer, and so on.
 

--- a/docs/src/content/docs/getting-started/concepts.mdx
+++ b/docs/src/content/docs/getting-started/concepts.mdx
@@ -51,8 +51,8 @@ When a pull request is opened or updated, Terrateam detects changes based on pat
 ```yaml
 when_modified:
   file_patterns:
-    - '**/*.tf'
-    - '**/*.tfvars'
+    - '${DIR}/*.tf'
+    - '${DIR}/*.tfvars'
 ```
 
 This configuration instructs Terrateam to monitor changes to any files with `.tf` or `.tfvars` extensions. Adjust these patterns in your configuration file to align with your project's structure.

--- a/docs/src/content/docs/getting-started/concepts.mdx
+++ b/docs/src/content/docs/getting-started/concepts.mdx
@@ -57,6 +57,15 @@ when_modified:
 
 This configuration instructs Terrateam to monitor changes to any files with `.tf` or `.tfvars` extensions. Adjust these patterns in your configuration file to align with your project's structure.
 
+:::tip[Configuration Flexibility]
+The `when_modified` configuration can be set at three levels:
+- **Global** - Applied to all directories
+- **Directory** - Under `dirs.<directory>.when_modified`
+- **Workspace** - Under `dirs.<directory>.workspaces.<workspace>.when_modified`
+
+All three levels use identical syntax. More specific configurations override broader ones.
+:::
+
 Terrateam maps detected changes to their appropriate [Dirspaces](/getting-started/concepts#dirspace). These mapped Dirspaces are referred to as Changes. When executing operations, Terrateam only considers Dirspaces with modified files in the pull request.
 
 ## Auto-Plan and Auto-Apply


### PR DESCRIPTION
## Description

Improve the `when_modified` documentation to express it can be configured on all three levels (global,dirs,workspace)

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Other (explain):

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/terrateamio/terrateam/blob/main/CONTRIBUTING.md)
- [x] The pull request title follows this format:
      `ISSUE_NUMBER ACTION_TYPE Short description` (e.g., `123 ADD Feature description`)
- [x] I have added tests and documentation (if applicable)
- [x] My changes generate no new warnings/errors and do not break existing functionality

## Additional context (optional)

<!-- Add any additional context here, e.g., screenshots, dependencies, etc. -->
