### PR TITLE
#654 FIX Isolate workspaces across runs

### DIFF
--- a/code/src/iris/Makefile
+++ b/code/src/iris/Makefile
@@ -1,16 +1,23 @@
 .PHONY: all release debug clean docs
 
-export npm_config_prefix:=$(PWD)/node_modules
 export BUILD_DIR:=$(PWD)
 export OUT_DIR:=$(BUILD_DIR)/dist
 
+SRC_FILES := $(shell find $(SRC_DIR) -type f)
+
 all: release
 
-release:
+# Use build.tag to track when the build was so we only run the build operations
+# again if something changed.  This is because whatever iris is being built with
+# performs work even if none of the files have changed.
+$(BUILD_DIR)/build.tag: $(SRC_FILES)
 	rsync -avr --delete --exclude='dist/' --exclude='node_modules/' $(SRC_DIR)/ ./src
 	cd src && ln -sf ../../../../../api_schemas/terrat/api.json ./api.json
 	cd src && npm i && npm run test && npm run build
 	ln -sf src/dist ./
+	touch $(BUILD_DIR)/build.tag
+
+release: $(BUILD_DIR)/build.tag
 
 debug: release
 

--- a/code/src/terrat_vcs_event_evaluator/terrat_vcs_event_evaluator.ml
+++ b/code/src/terrat_vcs_event_evaluator/terrat_vcs_event_evaluator.ml
@@ -3092,30 +3092,67 @@ module Make (S : Terrat_vcs_provider2.S) = struct
           checks
       else Abb.Future.return (Ok ())
 
+    (* Partitions a dirspaceflows by a few attributes:
+
+       1. The environment, so all environments get their own work manifest.
+
+       2. runs_on, so any runs that get their own runs_on configuration get
+          their own work manifest.
+
+       3. Overlapping workspaces.  This way if a dir has multiple workspace that
+          will run in it, it will get its own run.  This ensure isolation between
+          those directories. *)
     let partition_by_run_params ~max_workspaces_per_batch dirspaceflows =
       let module M = struct
         type t = string option * Yojson.Safe.t option [@@deriving eq]
       end in
       let module Dsf = Terrat_change.Dirspaceflow in
       let module We = Terrat_base_repo_config_v1.Workflows.Entry in
+      let partitioned_by_dir =
+        let rec update_first_match ~test ~update = function
+          | [] -> None
+          | x :: xs when test x -> Some (update x :: xs)
+          | x :: xs ->
+              let open CCOption.Infix in
+              update_first_match ~test ~update xs >>= fun xs -> Some (x :: xs)
+        in
+        let partitions =
+          CCList.fold_left
+            (fun groups ({ Dsf.dirspace = { Terrat_dirspace.dir; _ }; _ } as dsf) ->
+              match
+                update_first_match
+                  ~test:CCFun.(Terrat_data.String_map.mem dir %> not)
+                  ~update:(Terrat_data.String_map.add dir dsf)
+                  groups
+              with
+              | Some groups -> groups
+              | None -> Terrat_data.String_map.singleton dir dsf :: groups)
+            []
+            dirspaceflows
+        in
+        CCList.map CCFun.(Terrat_data.String_map.to_list %> CCList.map snd) partitions
+      in
       let partitions =
-        CCListLabels.fold_left
-          ~f:(fun acc dsf ->
-            let k =
-              match dsf with
-              | {
-               Dsf.workflow = Some { Dsf.Workflow.workflow = { We.environment; runs_on; _ }; _ };
-               _;
-              } -> (environment, runs_on)
-              | _ -> (None, None)
-            in
-            CCList.Assoc.update
-              ~eq:M.equal
-              ~f:(fun v -> Some (dsf :: CCOption.get_or ~default:[] v))
-              k
-              acc)
-          ~init:[]
-          dirspaceflows
+        CCList.flat_map
+          (fun dirspaceflows ->
+            CCListLabels.fold_left
+              ~f:(fun acc dsf ->
+                let k =
+                  match dsf with
+                  | {
+                   Dsf.workflow = Some { Dsf.Workflow.workflow = { We.environment; runs_on; _ }; _ };
+                   _;
+                  } -> (environment, runs_on)
+                  | _ -> (None, None)
+                in
+                CCList.Assoc.update
+                  ~eq:M.equal
+                  ~f:(fun v -> Some (dsf :: CCOption.get_or ~default:[] v))
+                  k
+                  acc)
+              ~init:[]
+              dirspaceflows)
+          partitioned_by_dir
       in
       CCList.flat_map
         (fun (k, dsfs) ->


### PR DESCRIPTION
If a run has modifications to the same directory but across different workspaces, we run the overlapping workspaces on different compute nodes.  This way we ensure that, even though, they will operate on the same directory, they will not interfere with each other.

## Description

<!-- Briefly describe the changes and the issue it fixes. -->

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (explain):

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/terrateamio/terrateam/blob/main/CONTRIBUTING.md)
- [x] The pull request title follows this format:
      `ISSUE_NUMBER ACTION_TYPE Short description` (e.g., `123 ADD Feature description`)
- [x] I have added tests and documentation (if applicable)
- [x] My changes generate no new warnings/errors and do not break existing functionality

## Additional context (optional)

<!-- Add any additional context here, e.g., screenshots, dependencies, etc. -->
