### PR TITLE
##603 REFACTOR remove platform from docker-compose now we have arm

### DIFF
--- a/docker/terrat/docker-compose.yml
+++ b/docker/terrat/docker-compose.yml
@@ -31,7 +31,6 @@ services:
   server:
     image: ghcr.io/terrateamio/terrat-oss:latest
     pull_policy: always
-    platform: linux/amd64
     environment:
       DB_HOST: "db"
       DB_PORT: "5432"


### PR DESCRIPTION
## Description

Don't explicitly set the platform in docker-compose now that we support arm64

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (explain):

## Checklist

- [ ] I have read the [contributing guidelines](https://github.com/terrateamio/terrateam/blob/main/CONTRIBUTING.md)
- [x] The pull request title follows this format:
      `ISSUE_NUMBER ACTION_TYPE Short description` (e.g., `123 ADD Feature description`)
- [x] I have added tests and documentation (if applicable)
- [x] My changes generate no new warnings/errors and do not break existing functionality

## Additional context (optional)

<!-- Add any additional context here, e.g., screenshots, dependencies, etc. -->
