### PR TITLE
#888 FIX Dirspace run state for when no steps are run for a dirspace

### DIFF
--- a/code/src/terrat_files/github/sql/select_dirspaces_page.sql
+++ b/code/src/terrat_files/github/sql/select_dirspaces_page.sql
@@ -96,7 +96,7 @@ select
     unified_run_type,
     (case
        when state = 'completed' and success then 'success'
-       when state = 'completed' and not success then 'failure'
+       when state = 'completed' and success is null or not success then 'failure'
        else state
     end) as state,
     tag_query,

--- a/code/src/terrat_files_gitlab/sql/select_dirspaces_page.sql
+++ b/code/src/terrat_files_gitlab/sql/select_dirspaces_page.sql
@@ -96,7 +96,7 @@ select
     unified_run_type,
     (case
        when state = 'completed' and success then 'success'
-       when state = 'completed' and not success then 'failure'
+       when state = 'completed' and success is null or not success then 'failure'
        else state
     end) as state,
     tag_query,


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes and the issue it fixes. -->

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (explain):

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/terrateamio/terrateam/blob/main/CONTRIBUTING.md)
- [x] The pull request title follows this format:
      `ISSUE_NUMBER ACTION_TYPE Short description` (e.g., `123 ADD Feature description`)
- [x] I have added tests and documentation (if applicable)
- [x] My changes generate no new warnings/errors and do not break existing functionality

## Additional context (optional)

<!-- Add any additional context here, e.g., screenshots, dependencies, etc. -->
