### PR TITLE
#949 ADD Support gitlab inputs, add runs_on to variables

### DIFF
--- a/api_schemas/gitlab_api/api.json
+++ b/api_schemas/gitlab_api/api.json
@@ -13071,43 +13071,16 @@
         "additionalProperties": false,
         "description": "Create a new pipeline",
         "properties": {
+          "inputs": {
+            "additionalProperties": true,
+            "description": "Key value pairs matching the expected inputa",
+            "nullable": true,
+            "type": "object"
+          },
           "ref": {
             "description": "Reference",
             "example": "develop",
             "type": "string"
-          },
-          "variables": {
-            "description": "Array of variables available in the pipeline",
-            "items": {
-              "additionalProperties": false,
-              "properties": {
-                "key": {
-                  "description": "The key of the variable",
-                  "example": "UPLOAD_TO_S3",
-                  "type": "string"
-                },
-                "value": {
-                  "description": "The value of the variable",
-                  "example": "true",
-                  "type": "string"
-                },
-                "variable_type": {
-                  "default": "env_var",
-                  "description": "The type of variable, must be one of env_var or file. Defaults to env_var",
-                  "enum": [
-                    "env_var",
-                    "file"
-                  ],
-                  "type": "string"
-                }
-              },
-              "required": [
-                "key",
-                "value"
-              ],
-              "type": "object"
-            },
-            "type": "array"
           }
         },
         "required": [

--- a/code/src/gitlabc/gitlabc_components_postapiv4projectsidpipeline.ml
+++ b/code/src/gitlabc/gitlabc_components_postapiv4projectsidpipeline.ml
@@ -1,28 +1,9 @@
-module Variables = struct
-  module Items = struct
-    module Variable_type = struct
-      let t_of_yojson = function
-        | `String "env_var" -> Ok "env_var"
-        | `String "file" -> Ok "file"
-        | json -> Error ("Unknown value: " ^ Yojson.Safe.pretty_to_string json)
-
-      type t = (string[@of_yojson t_of_yojson])
-      [@@deriving yojson { strict = false; meta = true }, show, eq]
-    end
-
-    type t = {
-      key : string;
-      value : string;
-      variable_type : Variable_type.t; [@default "env_var"]
-    }
-    [@@deriving yojson { strict = false; meta = true }, show, eq]
-  end
-
-  type t = Items.t list [@@deriving yojson { strict = false; meta = true }, show, eq]
+module Inputs = struct
+    include Json_schema.Additional_properties.Make (Json_schema.Empty_obj) (Json_schema.Obj)
 end
 
 type t = {
   ref_ : string; [@key "ref"]
-  variables : Variables.t option; [@default None]
+  inputs : Inputs.t option; [@default None]
 }
 [@@deriving yojson { strict = false; meta = true }, show, eq]

--- a/code/src/gitlabc/gitlabc_components_postapiv4projectsidpipeline.ml
+++ b/code/src/gitlabc/gitlabc_components_postapiv4projectsidpipeline.ml
@@ -1,9 +1,9 @@
 module Inputs = struct
-    include Json_schema.Additional_properties.Make (Json_schema.Empty_obj) (Json_schema.Obj)
+  include Json_schema.Additional_properties.Make (Json_schema.Empty_obj) (Json_schema.Obj)
 end
 
 type t = {
-  ref_ : string; [@key "ref"]
   inputs : Inputs.t option; [@default None]
+  ref_ : string; [@key "ref"]
 }
 [@@deriving yojson { strict = false; meta = true }, show, eq]

--- a/code/src/iris/src/lib/GettingStarted.svelte
+++ b/code/src/iris/src/lib/GettingStarted.svelte
@@ -3433,10 +3433,33 @@
                             <button
                               on:click={() => {
                                 const yamlContent = `# .gitlab-ci.yml - Using the terrateam template
-
+spec:
+  inputs:
+    TERRATEAM_TRIGGER:
+      description: "Is this being triggered by terrateam?"
+      type: boolean
+      default: false
+    WORK_TOKEN:
+      description: "The work token from terrateam"
+      type: string
+      default: ""
+    API_BASE_URL:
+      description: "The base url for the terrateam api"
+      type: string
+      default: ""
+    RUNS_ON:
+      description: "The tags to use for the runner"
+      type: array
+      default: []
+---
 include:
   - project: 'terrateam-io/terrateam-template'
     file: 'terrateam-template.yml'
+    inputs:
+      TERRATEAM_TRIGGER: $[[ inputs.TERRATEAM_TRIGGER ]]
+      WORK_TOKEN: $[[ inputs.WORK_TOKEN ]]
+      API_BASE_URL: $[[ inputs.API_BASE_URL ]]
+      RUNS_ON: $[[ inputs.RUNS_ON ]]
 
 stages:
   - terrateam
@@ -3453,10 +3476,33 @@ terrateam_job:
                               {copiedYaml ? 'Copied!' : 'Copy'}
                             </button>
                             <pre class="text-xs text-gray-800 dark:text-gray-200 overflow-x-auto pr-16"><code># .gitlab-ci.yml - Using the terrateam template
-
+spec:
+  inputs:
+    TERRATEAM_TRIGGER:
+      description: "Is this being triggered by terrateam?"
+      type: boolean
+      default: false
+    WORK_TOKEN:
+      description: "The work token from terrateam"
+      type: string
+      default: ""
+    API_BASE_URL:
+      description: "The base url for the terrateam api"
+      type: string
+      default: ""
+    RUNS_ON:
+      description: "The tags to use for the runner"
+      type: array
+      default: []
+---
 include:
   - project: 'terrateam-io/terrateam-template'
     file: 'terrateam-template.yml'
+    inputs:
+      TERRATEAM_TRIGGER: $[[ inputs.TERRATEAM_TRIGGER ]]
+      WORK_TOKEN: $[[ inputs.WORK_TOKEN ]]
+      API_BASE_URL: $[[ inputs.API_BASE_URL ]]
+      RUNS_ON: $[[ inputs.RUNS_ON ]]
 
 stages:
   - terrateam

--- a/code/src/terrat_vcs_service_gitlab/terrat_vcs_service_gitlab_provider.ml
+++ b/code/src/terrat_vcs_service_gitlab/terrat_vcs_service_gitlab_provider.ml
@@ -4283,35 +4283,22 @@ module Work_manifest = struct
       let body =
         {
           Pipeline.ref_ = get_branch work_manifest;
-          variables =
+          inputs =
             Some
-              Pipeline.Variables.Items.(
-                CCList.flatten
-                  [
-                    [
-                      { key = "TERRATEAM_TRIGGER"; value = "true"; variable_type = "env_var" };
-                      {
-                        key = "WORK_TOKEN";
-                        value = Ouuid.to_string work_manifest.Wm.id;
-                        variable_type = "env_var";
-                      };
-                      {
-                        key = "API_BASE_URL";
-                        value = Terrat_config.api_base (Api.Config.config config) ^ "/gitlab";
-                        variable_type = "env_var";
-                      };
-                    ];
-                    (match work_manifest.Wm.runs_on with
+              Pipeline.Inputs.
+                {
+                  primary = Json_schema.Empty_obj.t;
+                  additional = Json_schema.String_map.of_list
+                  ([
+                    ("TERRATEAM_TRIGGER", `Bool (true));
+                    ("WORK_TOKEN", `String (Ouuid.to_string work_manifest.Wm.id));
+                    ("API_BASE_URL", `String (Terrat_config.api_base (Api.Config.config config) ^ "/gitlab"));
+                  ] @
+                  match work_manifest.Wm.runs_on with
                     | Some runs_on ->
-                        [
-                          {
-                            key = "RUNS_ON";
-                            value = Yojson.Safe.to_string runs_on;
-                            variable_type = "env_var";
-                          };
-                        ]
+                      [ ("RUNS_ON", `String (Yojson.Safe.to_string runs_on)) ]
                     | None -> []);
-                  ]);
+                };
         }
       in
       Openapic_abb.call


### PR DESCRIPTION
## Description

Closes #949 

## Type of change

- [ ] Bug fix
- [x] New feature
- [x] Breaking change
- [x] Documentation update
- [ ] Other (explain):

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/terrateamio/terrateam/blob/main/CONTRIBUTING.md)
- [x] The pull request title follows this format:
      `ISSUE_NUMBER ACTION_TYPE Short description` (e.g., `123 ADD Feature description`)
- [ ] I have added tests and documentation (if applicable)
- [x] My changes generate no new warnings/errors and do not break existing functionality

## Additional context (optional)

Also requires https://gitlab.com/terrateam-io/terrateam-template/-/merge_requests/1

This is a breaking change for all gitlab repos. After merging everyone will need to change their ci to 

```yaml
# .gitlab-ci.yml - Using the terrateam template
spec:
  inputs:
    TERRATEAM_TRIGGER:
      description: "Is this being triggered by terrateam?"
      type: boolean
      default: false
    WORK_TOKEN:
      description: "The work token from terrateam"
      type: string
      default: ""
    API_BASE_URL:
      description: "The base url for the terrateam api"
      type: string
      default: ""
    RUNS_ON:
      description: "The tags to use for the runner"
      type: array
      default: []
---
include:
  - project: 'terrateam-io/terrateam-template'
    file: 'terrateam-template.yml'
    inputs:
      TERRATEAM_TRIGGER: $[[ inputs.TERRATEAM_TRIGGER ]]
      WORK_TOKEN: $[[ inputs.WORK_TOKEN ]]
      API_BASE_URL: $[[ inputs.API_BASE_URL ]]
      RUNS_ON: $[[ inputs.RUNS_ON ]]

stages:
  - terrateam

terrateam_job:
  extends: .terrateam_template
  ```