### PR TITLE
#837 FIX Default behavior for Automerge to avoid breaking certain workflows

### DIFF
--- a/api_schemas/terrat/config-schema.json
+++ b/api_schemas/terrat/config-schema.json
@@ -252,8 +252,9 @@
           "type": "boolean"
         },
         "merge_strategy": {
-          "default": "merge",
+          "default": "auto",
           "enum": [
+            "auto",
             "merge",
             "rebase",
             "squash"

--- a/code/src/terrat_base_repo_config_v1/terrat_base_repo_config_v1.ml
+++ b/code/src/terrat_base_repo_config_v1/terrat_base_repo_config_v1.ml
@@ -617,6 +617,7 @@ end
 module Automerge = struct
   module Merge_strategy = struct
     type t =
+      | Auto
       | Merge
       | Rebase
       | Squash
@@ -624,12 +625,14 @@ module Automerge = struct
 
     let make str =
       match str with
+      | "auto" -> Ok Auto
       | "merge" -> Ok Merge
       | "rebase" -> Ok Rebase
       | "squash" -> Ok Squash
       | _ -> Error (`Merge_strategy_parse_err str)
 
     let to_string = function
+      | Auto -> "auto"
       | Merge -> "merge"
       | Rebase -> "rebase"
       | Squash -> "squash"
@@ -638,7 +641,7 @@ module Automerge = struct
   type t = {
     delete_branch : bool; [@default false]
     enabled : bool; [@default false]
-    merge_strategy : Merge_strategy.t; [@default Merge_strategy.Merge]
+    merge_strategy : Merge_strategy.t; [@default Merge_strategy.Auto]
     require_explicit_apply : bool; [@default false]
   }
   [@@deriving make, show, yojson, eq]

--- a/code/src/terrat_base_repo_config_v1/terrat_base_repo_config_v1.mli
+++ b/code/src/terrat_base_repo_config_v1/terrat_base_repo_config_v1.mli
@@ -320,6 +320,7 @@ end
 module Automerge : sig
   module Merge_strategy : sig
     type t =
+      | Auto
       | Merge
       | Rebase
       | Squash

--- a/code/src/terrat_repo_config/terrat_repo_config_automerge.ml
+++ b/code/src/terrat_repo_config/terrat_repo_config_automerge.ml
@@ -1,5 +1,6 @@
 module Merge_strategy = struct
   let t_of_yojson = function
+    | `String "auto" -> Ok "auto"
     | `String "merge" -> Ok "merge"
     | `String "rebase" -> Ok "rebase"
     | `String "squash" -> Ok "squash"
@@ -12,7 +13,7 @@ end
 type t = {
   delete_branch : bool; [@default false]
   enabled : bool; [@default false]
-  merge_strategy : Merge_strategy.t; [@default "merge"]
+  merge_strategy : Merge_strategy.t; [@default "auto"]
   require_explicit_apply : bool; [@default false]
 }
 [@@deriving yojson { strict = true; meta = true }, make, show, eq]


### PR DESCRIPTION
## Description

Adds back a previous default behavior for Automerge.

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (explain):

## Checklist

- [X] I have read the [contributing guidelines](https://github.com/terrateamio/terrateam/blob/main/CONTRIBUTING.md)
- [X] The pull request title follows this format:
      `ISSUE_NUMBER ACTION_TYPE Short description` (e.g., `123 ADD Feature description`)
- [X] I have added tests and documentation (if applicable)
- [X] My changes generate no new warnings/errors and do not break existing functionality

## Additional context (optional)

<!-- Add any additional context here, e.g., screenshots, dependencies, etc. -->
