### PR TITLE
FIX Support page tab navigation border clipping on desktop

### DIFF
--- a/code/src/iris/src/lib/Support.svelte
+++ b/code/src/iris/src/lib/Support.svelte
@@ -115,13 +115,13 @@
         <!-- Tab Navigation -->
         <div class="mb-8">
           <div class="flex justify-center">
-            <div class="bg-white dark:bg-gray-800 rounded-lg p-1 md:p-2 shadow-lg border w-full max-w-2xl">
+            <div class="bg-white dark:bg-gray-800 rounded-lg p-1 md:p-2 shadow-lg border w-full md:w-auto">
               <div class="grid grid-cols-2 md:flex md:space-x-1">
                 <button
                   on:click={() => activeTab = 'support'}
-                  class="px-3 py-2 md:px-6 md:py-3 rounded-lg text-xs md:text-sm font-semibold transition-colors flex items-center justify-center
-                    {activeTab === 'support' 
-                      ? 'bg-blue-600 text-white shadow-md' 
+                  class="px-3 py-2 md:px-6 md:py-3 rounded-lg text-xs md:text-sm font-semibold transition-colors flex items-center justify-center whitespace-nowrap
+                    {activeTab === 'support'
+                      ? 'bg-blue-600 text-white shadow-md'
                       : 'text-brand-secondary hover:text-brand-primary hover:bg-gray-50 dark:hover:bg-gray-700'}"
                 >
                   <svg class="w-4 h-4 mr-1 md:mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -131,9 +131,9 @@
                 </button>
                 <button
                   on:click={() => activeTab = 'community'}
-                  class="px-3 py-2 md:px-6 md:py-3 rounded-lg text-xs md:text-sm font-semibold transition-colors flex items-center justify-center
-                    {activeTab === 'community' 
-                      ? 'bg-blue-600 text-white shadow-md' 
+                  class="px-3 py-2 md:px-6 md:py-3 rounded-lg text-xs md:text-sm font-semibold transition-colors flex items-center justify-center whitespace-nowrap
+                    {activeTab === 'community'
+                      ? 'bg-blue-600 text-white shadow-md'
                       : 'text-brand-secondary hover:text-brand-primary hover:bg-gray-50 dark:hover:bg-gray-700'}"
                 >
                   <svg class="w-4 h-4 mr-1 md:mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -143,9 +143,9 @@
                 </button>
                 <button
                   on:click={() => activeTab = 'resources'}
-                  class="px-3 py-2 md:px-6 md:py-3 rounded-lg text-xs md:text-sm font-semibold transition-colors flex items-center justify-center
-                    {activeTab === 'resources' 
-                      ? 'bg-blue-600 text-white shadow-md' 
+                  class="px-3 py-2 md:px-6 md:py-3 rounded-lg text-xs md:text-sm font-semibold transition-colors flex items-center justify-center whitespace-nowrap
+                    {activeTab === 'resources'
+                      ? 'bg-blue-600 text-white shadow-md'
                       : 'text-brand-secondary hover:text-brand-primary hover:bg-gray-50 dark:hover:bg-gray-700'}"
                 >
                   <svg class="w-4 h-4 mr-1 md:mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -155,9 +155,9 @@
                 </button>
                 <button
                   on:click={() => activeTab = 'status'}
-                  class="px-3 py-2 md:px-6 md:py-3 rounded-lg text-xs md:text-sm font-semibold transition-colors flex items-center justify-center
-                    {activeTab === 'status' 
-                      ? 'bg-blue-600 text-white shadow-md' 
+                  class="px-3 py-2 md:px-6 md:py-3 rounded-lg text-xs md:text-sm font-semibold transition-colors flex items-center justify-center whitespace-nowrap
+                    {activeTab === 'status'
+                      ? 'bg-blue-600 text-white shadow-md'
                       : 'text-brand-secondary hover:text-brand-primary hover:bg-gray-50 dark:hover:bg-gray-700'}"
                 >
                   <svg class="w-4 h-4 mr-1 md:mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">


### PR DESCRIPTION
## Description

### Summary
Fixes a UI issue where the tab navigation border on the Support page is clipped on desktop screen sizes.

### Problem
The Support page tab container was limited to `max-w-2xl` (672px).  
When all four tabs ("Technical Support", "Community", "Resources", "Status") were shown, their combined width exceeded this limit, causing the right border (near **Status**) to be cut off on desktop.

### Changes  
**File:** `src/lib/Support.svelte`

#### 1. Container width adjustment
- `max-w-2xl` → `md:w-auto`
- Mobile: still uses `w-full`  
- Desktop: expands automatically to fit the tab content

#### 2. Prevent text wrapping in tab labels
<img width="771" height="359" alt="스크린샷 2025-12-23 오후 6 10 17" src="https://github.com/user-attachments/assets/9d81a205-ba65-4489-b063-e4aa2981b924" />

- Added `whitespace-nowrap` to all four tab buttons
- Ensures labels stay on one line and prevents inconsistent sizing

---

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (explain):

---

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/terrateamio/terrateam/blob/main/CONTRIBUTING.md)
- [x] The pull request title follows the required format:
      `1057 FIX Support page tab navigation border clipping`
- [x] My changes introduce no warnings or UI regressions
- [x] I tested on desktop, tablet, and mobile screen sizes

---

## Additional context (optional)

Screenshots provided in Issue #1057.  
No functional changes—UI only.

