### PR TITLE
#978 FIX Storing repo tree cache

### DIFF
--- a/scripts/deploy_flyio
+++ b/scripts/deploy_flyio
@@ -5,4 +5,4 @@ IMAGE_NAME="terrat-ee"
 GHCR_IMAGE="ghcr.io/${GITHUB_REPOSITORY_OWNER}/${IMAGE_NAME}:${VERSION_TAG}"
 FLY_APP_PREFIX="${FLY_APP_PREFIX:-terrateam-app}"
 
-flyctl deploy --strategy bluegreen --access-token "${FLY_API_TOKEN}" --image "${GHCR_IMAGE}" -a "${FLY_APP_PREFIX}-${TERRATEAM_ENVIRONMENT}"
+flyctl deploy --strategy canary --access-token "${FLY_API_TOKEN}" --image "${GHCR_IMAGE}" -a "${FLY_APP_PREFIX}-${TERRATEAM_ENVIRONMENT}"


### PR DESCRIPTION
The cache was overwriting the same index over and over again rather than appending to the index, so it was only storing the last list of files in the cache.

This fixes it to increment the index on each store.

## Description

<!-- Briefly describe the changes and the issue it fixes. -->

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (explain):

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/terrateamio/terrateam/blob/main/CONTRIBUTING.md)
- [x] The pull request title follows this format:
      `ISSUE_NUMBER ACTION_TYPE Short description` (e.g., `123 ADD Feature description`)
- [x] I have added tests and documentation (if applicable)
- [x] My changes generate no new warnings/errors and do not break existing functionality

## Additional context (optional)

<!-- Add any additional context here, e.g., screenshots, dependencies, etc. -->
