### PR TITLE
#719 ADD Track last drift is run in the database rather than infer vi…

### DIFF
--- a/code/src/terrat_files/github/sql/select_missing_drift_scheduled_runs.sql
+++ b/code/src/terrat_files/github/sql/select_missing_drift_scheduled_runs.sql
@@ -9,6 +9,7 @@ ds as (
          when 'weekly' then interval '1 week'
          when 'monthly' then interval '1 month'
          end) as schedule,
+         nullif(branch, '') as branch,
          ds.reconcile,
          ds.tag_query,
          ds.updated_at,
@@ -19,29 +20,6 @@ ds as (
     inner join github_repositories_map as grm
         on grm.core_id = ds.repo
     where schedule in ('hourly', 'daily', 'weekly', 'monthly')
-),
-latest_drift_unlocks as (
-    select
-        repository,
-        max(unlocked_at) as unlocked_at
-    from github_drift_unlocks
-    group by repository
-),
-dwms as (
-    select
-        gwm.repository as repository,
-        gwm.created_at as created_at,
-        gwm.state as state,
-        row_number() over (partition by gwm.repository order by gwm.created_at desc) as rn
-    from drift_work_manifests as dwm
-    inner join github_work_manifests as gwm
-        on gwm.id = dwm.work_manifest
-    left join latest_drift_unlocks
-        on latest_drift_unlocks.repository = gwm.repository
-    where latest_drift_unlocks.repository is null or latest_drift_unlocks.unlocked_at < gwm.created_at
-),
-latest_drift_manifests as (
-    select * from dwms where rn = 1
 ),
 drift_schedule_windows as (
     select
@@ -54,34 +32,55 @@ drift_schedule_windows as (
          end) as window_end
     from ds
     where window_start is not null and window_end is not null
+),
+chosen_drift_schedule as (
+    select
+        ds.name as drift_name,
+        gir.installation_id as installation_id,
+        gir.id as repository,
+        gir.owner as owner,
+        gir.name as name,
+        ds.branch,
+        ds.reconcile,
+        ds.tag_query,
+        dsw.window_start,
+        dsw.window_end,
+        ds.repo_core_id
+    from ds
+    inner join drift_schedules
+        on drift_schedules.repo = ds.repo_core_id and drift_schedules.name = ds.name
+    inner join github_installation_repositories as gir
+        on gir.id = ds.repository
+    inner join github_installations as gi
+        on gi.id = gir.installation_id
+    left join drift_schedule_windows as dsw
+        on (dsw.repository, dsw.name) = (ds.repository, ds.name)
+    where (dsw.window_start is null
+           or (dsw.window_start <= current_timestamp and current_timestamp < dsw.window_end))
+          and gi.state = 'installed'
+          -- Running a schedule might fail immediately, so force at least 1 minute between tries
+          and (drift_schedules.last_tried_at is null
+               or drift_schedules.last_tried_at < now() - ds.schedule
+               or drift_schedules.last_tried_at < drift_schedules.updated_at)
+    limit 1
+),
+updated_last_tried as (
+    update drift_schedules as ds
+      set last_tried_at = now()
+    from chosen_drift_schedule as cds
+    where cds.repo_core_id = ds.repo
+          and (cds.branch is null and ds.branch = '' or ds.branch = cds.branch)
+          and ds.name = cds.drift_name
+    returning cds.*
 )
 select
-    ds.name as drift_name,
-    gir.installation_id as installation_id,
-    gir.id as repository,
-    gir.owner as owner,
-    gir.name as name,
-    ds.reconcile,
-    ds.tag_query,
-    dsw.window_start,
-    dsw.window_end
-from ds
-inner join drift_schedules
-    on drift_schedules.repo = ds.repo_core_id and drift_schedules.name = ds.name
-inner join github_installation_repositories as gir
-    on gir.id = ds.repository
-inner join github_installations as gi
-    on gi.id = gir.installation_id
-left join latest_drift_manifests as ldm
-    on ldm.repository = ds.repository
-left join drift_schedule_windows as dsw
-    on (dsw.repository, dsw.name) = (ds.repository, ds.name)
-where (ldm.state is null or ldm.state not in ('queued', 'running'))
-      and ((ldm.repository is null
-            or ds.schedule < (current_timestamp - ldm.created_at)
-            or ldm.created_at < ds.updated_at)
-           and (dsw.window_start is null
-                or (dsw.window_start <= current_timestamp and current_timestamp < dsw.window_end)))
-      and gi.state = 'installed'
-limit 1
-for update of drift_schedules skip locked
+    drift_name,
+    installation_id,
+    repository,
+    owner,
+    name,
+    reconcile,
+    tag_query,
+    window_start,
+    window_end
+from updated_last_tried

--- a/code/src/terrat_files_gitlab/sql/select_missing_drift_scheduled_runs.sql
+++ b/code/src/terrat_files_gitlab/sql/select_missing_drift_scheduled_runs.sql
@@ -9,6 +9,7 @@ ds as (
          when 'weekly' then interval '1 week'
          when 'monthly' then interval '1 month'
          end) as schedule,
+         nullif(branch, '') as branch,
          ds.reconcile,
          ds.tag_query,
          ds.updated_at,
@@ -19,29 +20,6 @@ ds as (
     inner join gitlab_repositories_map as grm
         on grm.core_id = ds.repo
     where schedule in ('hourly', 'daily', 'weekly', 'monthly')
-),
-latest_drift_unlocks as (
-    select
-        repository,
-        max(unlocked_at) as unlocked_at
-    from gitlab_drift_unlocks
-    group by repository
-),
-dwms as (
-    select
-        gwm.repository as repository,
-        gwm.created_at as created_at,
-        gwm.state as state,
-        row_number() over (partition by gwm.repository order by gwm.created_at desc) as rn
-    from drift_work_manifests as dwm
-    inner join gitlab_work_manifests as gwm
-        on gwm.id = dwm.work_manifest
-    left join latest_drift_unlocks
-        on latest_drift_unlocks.repository = gwm.repository
-    where latest_drift_unlocks.repository is null or latest_drift_unlocks.unlocked_at < gwm.created_at
-),
-latest_drift_manifests as (
-    select * from dwms where rn = 1
 ),
 drift_schedule_windows as (
     select
@@ -54,34 +32,55 @@ drift_schedule_windows as (
          end) as window_end
     from ds
     where window_start is not null and window_end is not null
+),
+chosen_drift_schedule as (
+    select
+        ds.name as drift_name,
+        gir.installation_id as installation_id,
+        gir.id as repository,
+        gir.owner as owner,
+        gir.name as name,
+        ds.branch,
+        ds.reconcile,
+        ds.tag_query,
+        dsw.window_start,
+        dsw.window_end,
+        ds.repo_core_id
+    from ds
+    inner join drift_schedules
+        on drift_schedules.repo = ds.repo_core_id and drift_schedules.name = ds.name
+    inner join gitlab_installation_repositories as gir
+        on gir.id = ds.repository
+    inner join gitlab_installations as gi
+        on gi.id = gir.installation_id
+    left join drift_schedule_windows as dsw
+        on (dsw.repository, dsw.name) = (ds.repository, ds.name)
+    where (dsw.window_start is null
+           or (dsw.window_start <= current_timestamp and current_timestamp < dsw.window_end))
+          and gi.state = 'installed'
+          -- Running a schedule might fail immediately, so force at least 1 minute between tries
+          and (drift_schedules.last_tried_at is null
+               or drift_schedules.last_tried_at < now() - ds.schedule
+               or drift_schedules.last_tried_at < drift_schedules.updated_at)
+    limit 1
+),
+updated_last_tried as (
+    update drift_schedules as ds
+      set last_tried_at = now()
+    from chosen_drift_schedule as cds
+    where cds.repo_core_id = ds.repo
+          and (cds.branch is null and ds.branch = '' or ds.branch = cds.branch)
+          and ds.name = cds.drift_name
+    returning cds.*
 )
 select
-    ds.name as drift_name,
-    gir.installation_id as installation_id,
-    gir.id as repository,
-    gir.owner as owner,
-    gir.name as name,
-    ds.reconcile,
-    ds.tag_query,
-    dsw.window_start,
-    dsw.window_end
-from ds
-inner join drift_schedules
-    on drift_schedules.repo = ds.repo_core_id and drift_schedules.name = ds.name
-inner join gitlab_installation_repositories as gir
-    on gir.id = ds.repository
-inner join gitlab_installations as gi
-    on gi.id = gir.installation_id
-left join latest_drift_manifests as ldm
-    on ldm.repository = ds.repository
-left join drift_schedule_windows as dsw
-    on (dsw.repository, dsw.name) = (ds.repository, ds.name)
-where (ldm.state is null or ldm.state not in ('queued', 'running'))
-      and ((ldm.repository is null
-            or ds.schedule < (current_timestamp - ldm.created_at)
-            or ldm.created_at < ds.updated_at)
-           and (dsw.window_start is null
-                or (dsw.window_start <= current_timestamp and current_timestamp < dsw.window_end)))
-      and gi.state = 'installed'
-limit 1
-for update of drift_schedules skip locked
+    drift_name,
+    installation_id,
+    repository,
+    owner,
+    name,
+    reconcile,
+    tag_query,
+    window_start,
+    window_end
+from updated_last_tried


### PR DESCRIPTION
…a work manfiest

This is a big divergence from how drift previous ran.  Before, drift would look for a drift work manifest run in the repository and if it was not done, it would not run drift.

This is actually quite broken, though.  When there was only one drift allowed per repository it was fine, but with multiple drift schedules, we do not actually have any linkage between the work manifest and the drift schedule, so we can end up skipping some drift schedule runs because the work manifest run is blocking it.

Consider, for example, we have two schedules: daily and hourly.  The hourly one will run every hour, and will block the daily one, because every time it looks to run it will see there has been a work manifest run in the last day (the hourly run).

The correct solution is to connect a work manifest to a specific schedule, but we don't have the machinery for that for now, so this tracks in the schedule the last time the drift was tried and only tries again after that schedule (this, btw, is also useful if a drift run is failing, for example if the repository no longer exists, it will guarantee we do not keep on trying it forever).

However, what this also means, is that we will try on the schedule, every schedule.  So if we have an hourly drift and it takes more than an hour to run, we will have two running for some period of time.

In reality, I think this is probably OK.  The main issue people have with drift is that it seems to get stuck and it doesn't run and they don't know why because drift is a background task, so this would solve that.

The tricky part is about reconciliation.  But the event evaluator makes it so no two reconciliation drifts for overlapping dirspaces happen at the same time.

## Description

<!-- Briefly describe the changes and the issue it fixes. -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Breaking change
- [ ] Documentation update
- [ ] Other (explain):

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/terrateamio/terrateam/blob/main/CONTRIBUTING.md)
- [x] The pull request title follows this format:
      `ISSUE_NUMBER ACTION_TYPE Short description` (e.g., `123 ADD Feature description`)
- [x] I have added tests and documentation (if applicable)
- [x] My changes generate no new warnings/errors and do not break existing functionality

## Additional context (optional)

<!-- Add any additional context here, e.g., screenshots, dependencies, etc. -->
