### PR TITLE
#1131 FIX db port customization

### DIFF
--- a/code/src/terrat_config/terrat_config.ml
+++ b/code/src/terrat_config/terrat_config.ml
@@ -95,6 +95,7 @@ type t = {
   db : string;
   db_connect_timeout : float;
   db_host : string;
+  db_port : int;
   db_idle_tx_timeout : string;
   db_max_pool_size : int;
   db_password : (string[@opaque]);
@@ -271,6 +272,10 @@ let create () =
   >>= fun port ->
   env_str "DB_HOST"
   >>= fun db_host ->
+  of_opt
+    (`Key_error "DB_PORT")
+    (CCInt.of_string (CCOption.get_or ~default:"5432" (Sys.getenv_opt "DB_PORT")))
+  >>= fun db_port ->
   let db_idle_tx_timeout = CCOption.get_or ~default:"180s" (Sys.getenv_opt "DB_IDLE_TX_TIMEOUT") in
   env_str "DB_USER"
   >>= fun db_user ->
@@ -334,6 +339,7 @@ let create () =
       db;
       db_connect_timeout;
       db_host;
+      db_port;
       db_idle_tx_timeout;
       db_max_pool_size;
       db_password;
@@ -357,6 +363,7 @@ let api_base t = t.api_base
 let db t = t.db
 let db_connect_timeout t = t.db_connect_timeout
 let db_host t = t.db_host
+let db_port t = t.db_port
 let db_idle_tx_timeout t = t.db_idle_tx_timeout
 let db_max_pool_size t = t.db_max_pool_size
 let db_password t = t.db_password

--- a/code/src/terrat_config/terrat_config.mli
+++ b/code/src/terrat_config/terrat_config.mli
@@ -71,6 +71,7 @@ val create : unit -> (t, [> err ]) result
 val db : t -> string
 val db_connect_timeout : t -> float
 val db_host : t -> string
+val db_port : t -> int
 val db_idle_tx_timeout : t -> string
 val db_max_pool_size : t -> int
 val db_password : t -> string

--- a/code/src/terrat_storage/terrat_storage.ml
+++ b/code/src/terrat_storage/terrat_storage.ml
@@ -59,6 +59,7 @@ let create config =
     ~host:(Terrat_config.db_host config)
     ~user:(Terrat_config.db_user config)
     ~passwd:(Terrat_config.db_password config)
+    ?port:(Some (Terrat_config.db_port config))
     ~max_conns:(Terrat_config.db_max_pool_size config)
     ~connect_timeout:(Terrat_config.db_connect_timeout config)
     ~on_connect:(on_connect (Terrat_config.db_idle_tx_timeout config))


### PR DESCRIPTION
## Description

This allows to use DB_PORT for specifying PostgreSQL port during migrations and database connections and fixes #1131

Attention! 
I don't know any ocaml and the code is AI generated, so, please, review.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (explain):

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/terrateamio/terrateam/blob/main/CONTRIBUTING.md)
- [x] The pull request title follows this format:
      `ISSUE_NUMBER ACTION_TYPE Short description` (e.g., `123 ADD Feature description`)
- [ ] I have added tests and documentation (if applicable)
- [ ] My changes generate no new warnings/errors and do not break existing functionality

## Additional context (optional)

<!-- Add any additional context here, e.g., screenshots, dependencies, etc. -->
