### PR TITLE
1141 FIX webhook pull_request.synchronize parsing

### DIFF
--- a/api_schemas/github_webhooks/terrat-schema.json
+++ b/api_schemas/github_webhooks/terrat-schema.json
@@ -1837,7 +1837,7 @@
           ]
         },
         "additions": {
-          "type": "integer"
+          "type": ["integer", "null"]
         },
         "assignee": {
           "$ref": "#/definitions/user"
@@ -1889,7 +1889,7 @@
           ]
         },
         "changed_files": {
-          "type": "integer"
+          "type": ["integer", "null"]
         },
         "closed_at": {
           "format": "date-time",
@@ -1899,14 +1899,14 @@
           ]
         },
         "comments": {
-          "type": "integer"
+          "type": ["integer", "null"]
         },
         "comments_url": {
           "format": "uri",
           "type": "string"
         },
         "commits": {
-          "type": "integer"
+          "type": ["integer", "null"]
         },
         "commits_url": {
           "format": "uri",
@@ -1917,7 +1917,7 @@
           "type": "string"
         },
         "deletions": {
-          "type": "integer"
+          "type": ["integer", "null"]
         },
         "diff_url": {
           "format": "uri",
@@ -1977,7 +1977,7 @@
         },
         "maintainer_can_modify": {
           "description": "Indicates whether maintainers can modify the pull request.",
-          "type": "boolean"
+          "type": ["boolean", "null"]
         },
         "merge_commit_sha": {
           "type": [
@@ -1992,7 +1992,7 @@
           ]
         },
         "mergeable_state": {
-          "type": "string"
+          "type": ["string", "null"]
         },
         "merged": {
           "type": [
@@ -2054,7 +2054,7 @@
           "type": "string"
         },
         "review_comments": {
-          "type": "integer"
+          "type": ["integer", "null"]
         },
         "review_comments_url": {
           "format": "uri",
@@ -2124,15 +2124,7 @@
         "draft",
         "merged",
         "mergeable",
-        "rebaseable",
-        "mergeable_state",
-        "comments",
-        "review_comments",
-        "maintainer_can_modify",
-        "commits",
-        "additions",
-        "deletions",
-        "changed_files"
+        "rebaseable"
       ],
       "title": "Pull Request",
       "type": "object"

--- a/code/src/terrat_github_webhooks/terrat_github_webhooks_pull_request.ml
+++ b/code/src/terrat_github_webhooks/terrat_github_webhooks_pull_request.ml
@@ -85,21 +85,21 @@ end
 type t = {
   links_ : Links_.t; [@key "_links"]
   active_lock_reason : string option; [@default None]
-  additions : int;
+  additions : int option; [@default None]
   assignee : Terrat_github_webhooks_user.t option; [@default None]
   assignees : Assignees.t;
   author_association : string;
   auto_merge : Terrat_github_webhooks_auto_merge.t option; [@default None]
   base : Base.t;
   body : string option; [@default None]
-  changed_files : int;
+  changed_files : int option; [@default None]
   closed_at : string option; [@default None]
-  comments : int;
+  comments : int option; [@default None]
   comments_url : string;
-  commits : int;
+  commits : int option; [@default None]
   commits_url : string;
   created_at : string;
-  deletions : int;
+  deletions : int option; [@default None]
   diff_url : string;
   draft : bool;
   head : Head.t;
@@ -108,10 +108,10 @@ type t = {
   issue_url : string;
   labels : Labels.t;
   locked : bool;
-  maintainer_can_modify : bool;
+  maintainer_can_modify : bool option; [@default None]
   merge_commit_sha : string option; [@default None]
   mergeable : bool option; [@default None]
-  mergeable_state : string;
+  mergeable_state : string option; [@default None]
   merged : bool option; [@default None]
   merged_at : string option; [@default None]
   merged_by : Terrat_github_webhooks_user.t option; [@default None]
@@ -123,7 +123,7 @@ type t = {
   requested_reviewers : Requested_reviewers.t;
   requested_teams : Requested_teams.t;
   review_comment_url : string;
-  review_comments : int;
+  review_comments : int option; [@default None]
   review_comments_url : string;
   state : State.t;
   statuses_url : string;

--- a/code/src/terrat_github_webhooks/terrat_github_webhooks_pull_request_closed.ml
+++ b/code/src/terrat_github_webhooks/terrat_github_webhooks_pull_request_closed.ml
@@ -97,21 +97,21 @@ module Pull_request_ = struct
       type t = {
         links_ : Links_.t; [@key "_links"]
         active_lock_reason : string option; [@default None]
-        additions : int;
+        additions : int option; [@default None]
         assignee : Terrat_github_webhooks_user.t option; [@default None]
         assignees : Assignees.t;
         author_association : string;
         auto_merge : Terrat_github_webhooks_auto_merge.t option; [@default None]
         base : Base.t;
         body : string option; [@default None]
-        changed_files : int;
+        changed_files : int option; [@default None]
         closed_at : string option; [@default None]
-        comments : int;
+        comments : int option; [@default None]
         comments_url : string;
-        commits : int;
+        commits : int option; [@default None]
         commits_url : string;
         created_at : string;
-        deletions : int;
+        deletions : int option; [@default None]
         diff_url : string;
         draft : bool;
         head : Head.t;
@@ -120,10 +120,10 @@ module Pull_request_ = struct
         issue_url : string;
         labels : Labels.t;
         locked : bool;
-        maintainer_can_modify : bool;
+        maintainer_can_modify : bool option; [@default None]
         merge_commit_sha : string option; [@default None]
         mergeable : bool option; [@default None]
-        mergeable_state : string;
+        mergeable_state : string option; [@default None]
         merged : bool option; [@default None]
         merged_at : string option; [@default None]
         merged_by : Terrat_github_webhooks_user.t option; [@default None]
@@ -135,7 +135,7 @@ module Pull_request_ = struct
         requested_reviewers : Requested_reviewers.t;
         requested_teams : Requested_teams.t;
         review_comment_url : string;
-        review_comments : int;
+        review_comments : int option; [@default None]
         review_comments_url : string;
         state : State.t;
         statuses_url : string;
@@ -239,21 +239,21 @@ module Pull_request_ = struct
       type t = {
         links_ : Links_.t; [@key "_links"]
         active_lock_reason : string option; [@default None]
-        additions : int;
+        additions : int option; [@default None]
         assignee : Terrat_github_webhooks_user.t option; [@default None]
         assignees : Assignees.t;
         author_association : string;
         auto_merge : Terrat_github_webhooks_auto_merge.t option; [@default None]
         base : Base.t;
         body : string option; [@default None]
-        changed_files : int;
+        changed_files : int option; [@default None]
         closed_at : string option; [@default None]
-        comments : int;
+        comments : int option; [@default None]
         comments_url : string;
-        commits : int;
+        commits : int option; [@default None]
         commits_url : string;
         created_at : string;
-        deletions : int;
+        deletions : int option; [@default None]
         diff_url : string;
         draft : bool;
         head : Head.t;
@@ -262,10 +262,10 @@ module Pull_request_ = struct
         issue_url : string;
         labels : Labels.t;
         locked : bool;
-        maintainer_can_modify : bool;
+        maintainer_can_modify : bool option; [@default None]
         merge_commit_sha : string option; [@default None]
         mergeable : bool option; [@default None]
-        mergeable_state : string;
+        mergeable_state : string option; [@default None]
         merged : bool option; [@default None]
         merged_at : string option; [@default None]
         merged_by : Terrat_github_webhooks_user.t option; [@default None]
@@ -277,7 +277,7 @@ module Pull_request_ = struct
         requested_reviewers : Requested_reviewers.t;
         requested_teams : Requested_teams.t;
         review_comment_url : string;
-        review_comments : int;
+        review_comments : int option; [@default None]
         review_comments_url : string;
         state : State.t;
         statuses_url : string;

--- a/code/src/terrat_github_webhooks/terrat_github_webhooks_pull_request_converted_to_draft.ml
+++ b/code/src/terrat_github_webhooks/terrat_github_webhooks_pull_request_converted_to_draft.ml
@@ -101,21 +101,21 @@ module Pull_request_ = struct
       type t = {
         links_ : Links_.t; [@key "_links"]
         active_lock_reason : string option; [@default None]
-        additions : int;
+        additions : int option; [@default None]
         assignee : Terrat_github_webhooks_user.t option; [@default None]
         assignees : Assignees.t;
         author_association : string;
         auto_merge : Terrat_github_webhooks_auto_merge.t option; [@default None]
         base : Base.t;
         body : string option; [@default None]
-        changed_files : int;
+        changed_files : int option; [@default None]
         closed_at : string option; [@default None]
-        comments : int;
+        comments : int option; [@default None]
         comments_url : string;
-        commits : int;
+        commits : int option; [@default None]
         commits_url : string;
         created_at : string;
-        deletions : int;
+        deletions : int option; [@default None]
         diff_url : string;
         draft : bool;
         head : Head.t;
@@ -124,10 +124,10 @@ module Pull_request_ = struct
         issue_url : string;
         labels : Labels.t;
         locked : bool;
-        maintainer_can_modify : bool;
+        maintainer_can_modify : bool option; [@default None]
         merge_commit_sha : string option; [@default None]
         mergeable : bool option; [@default None]
-        mergeable_state : string;
+        mergeable_state : string option; [@default None]
         merged : bool option; [@default None]
         merged_at : string option; [@default None]
         merged_by : Merged_by.t;
@@ -139,7 +139,7 @@ module Pull_request_ = struct
         requested_reviewers : Requested_reviewers.t;
         requested_teams : Requested_teams.t;
         review_comment_url : string;
-        review_comments : int;
+        review_comments : int option; [@default None]
         review_comments_url : string;
         state : State.t;
         statuses_url : string;
@@ -247,21 +247,21 @@ module Pull_request_ = struct
       type t = {
         links_ : Links_.t; [@key "_links"]
         active_lock_reason : string option; [@default None]
-        additions : int;
+        additions : int option; [@default None]
         assignee : Terrat_github_webhooks_user.t option; [@default None]
         assignees : Assignees.t;
         author_association : string;
         auto_merge : Terrat_github_webhooks_auto_merge.t option; [@default None]
         base : Base.t;
         body : string option; [@default None]
-        changed_files : int;
+        changed_files : int option; [@default None]
         closed_at : string option; [@default None]
-        comments : int;
+        comments : int option; [@default None]
         comments_url : string;
-        commits : int;
+        commits : int option; [@default None]
         commits_url : string;
         created_at : string;
-        deletions : int;
+        deletions : int option; [@default None]
         diff_url : string;
         draft : bool;
         head : Head.t;
@@ -270,10 +270,10 @@ module Pull_request_ = struct
         issue_url : string;
         labels : Labels.t;
         locked : bool;
-        maintainer_can_modify : bool;
+        maintainer_can_modify : bool option; [@default None]
         merge_commit_sha : string option; [@default None]
         mergeable : bool option; [@default None]
-        mergeable_state : string;
+        mergeable_state : string option; [@default None]
         merged : bool option; [@default None]
         merged_at : string option; [@default None]
         merged_by : Merged_by.t;
@@ -285,7 +285,7 @@ module Pull_request_ = struct
         requested_reviewers : Requested_reviewers.t;
         requested_teams : Requested_teams.t;
         review_comment_url : string;
-        review_comments : int;
+        review_comments : int option; [@default None]
         review_comments_url : string;
         state : State.t;
         statuses_url : string;

--- a/code/src/terrat_github_webhooks/terrat_github_webhooks_pull_request_opened.ml
+++ b/code/src/terrat_github_webhooks/terrat_github_webhooks_pull_request_opened.ml
@@ -101,21 +101,21 @@ module Pull_request_ = struct
       type t = {
         links_ : Links_.t; [@key "_links"]
         active_lock_reason : string option; [@default None]
-        additions : int;
+        additions : int option; [@default None]
         assignee : Terrat_github_webhooks_user.t option; [@default None]
         assignees : Assignees.t;
         author_association : string;
         auto_merge : Terrat_github_webhooks_auto_merge.t option; [@default None]
         base : Base.t;
         body : string option; [@default None]
-        changed_files : int;
+        changed_files : int option; [@default None]
         closed_at : string option; [@default None]
-        comments : int;
+        comments : int option; [@default None]
         comments_url : string;
-        commits : int;
+        commits : int option; [@default None]
         commits_url : string;
         created_at : string;
-        deletions : int;
+        deletions : int option; [@default None]
         diff_url : string;
         draft : bool;
         head : Head.t;
@@ -124,10 +124,10 @@ module Pull_request_ = struct
         issue_url : string;
         labels : Labels.t;
         locked : bool;
-        maintainer_can_modify : bool;
+        maintainer_can_modify : bool option; [@default None]
         merge_commit_sha : string option; [@default None]
         mergeable : bool option; [@default None]
-        mergeable_state : string;
+        mergeable_state : string option; [@default None]
         merged : bool option; [@default None]
         merged_at : string option; [@default None]
         merged_by : Merged_by.t;
@@ -139,7 +139,7 @@ module Pull_request_ = struct
         requested_reviewers : Requested_reviewers.t;
         requested_teams : Requested_teams.t;
         review_comment_url : string;
-        review_comments : int;
+        review_comments : int option; [@default None]
         review_comments_url : string;
         state : State.t;
         statuses_url : string;
@@ -247,21 +247,21 @@ module Pull_request_ = struct
       type t = {
         links_ : Links_.t; [@key "_links"]
         active_lock_reason : string option; [@default None]
-        additions : int;
+        additions : int option; [@default None]
         assignee : Terrat_github_webhooks_user.t option; [@default None]
         assignees : Assignees.t;
         author_association : string;
         auto_merge : Terrat_github_webhooks_auto_merge.t option; [@default None]
         base : Base.t;
         body : string option; [@default None]
-        changed_files : int;
+        changed_files : int option; [@default None]
         closed_at : string option; [@default None]
-        comments : int;
+        comments : int option; [@default None]
         comments_url : string;
-        commits : int;
+        commits : int option; [@default None]
         commits_url : string;
         created_at : string;
-        deletions : int;
+        deletions : int option; [@default None]
         diff_url : string;
         draft : bool;
         head : Head.t;
@@ -270,10 +270,10 @@ module Pull_request_ = struct
         issue_url : string;
         labels : Labels.t;
         locked : bool;
-        maintainer_can_modify : bool;
+        maintainer_can_modify : bool option; [@default None]
         merge_commit_sha : string option; [@default None]
         mergeable : bool option; [@default None]
-        mergeable_state : string;
+        mergeable_state : string option; [@default None]
         merged : bool option; [@default None]
         merged_at : string option; [@default None]
         merged_by : Merged_by.t;
@@ -285,7 +285,7 @@ module Pull_request_ = struct
         requested_reviewers : Requested_reviewers.t;
         requested_teams : Requested_teams.t;
         review_comment_url : string;
-        review_comments : int;
+        review_comments : int option; [@default None]
         review_comments_url : string;
         state : State.t;
         statuses_url : string;

--- a/code/src/terrat_github_webhooks/terrat_github_webhooks_pull_request_ready_for_review.ml
+++ b/code/src/terrat_github_webhooks/terrat_github_webhooks_pull_request_ready_for_review.ml
@@ -101,21 +101,21 @@ module Pull_request_ = struct
       type t = {
         links_ : Links_.t; [@key "_links"]
         active_lock_reason : string option; [@default None]
-        additions : int;
+        additions : int option; [@default None]
         assignee : Terrat_github_webhooks_user.t option; [@default None]
         assignees : Assignees.t;
         author_association : string;
         auto_merge : Terrat_github_webhooks_auto_merge.t option; [@default None]
         base : Base.t;
         body : string option; [@default None]
-        changed_files : int;
+        changed_files : int option; [@default None]
         closed_at : string option; [@default None]
-        comments : int;
+        comments : int option; [@default None]
         comments_url : string;
-        commits : int;
+        commits : int option; [@default None]
         commits_url : string;
         created_at : string;
-        deletions : int;
+        deletions : int option; [@default None]
         diff_url : string;
         draft : bool;
         head : Head.t;
@@ -124,10 +124,10 @@ module Pull_request_ = struct
         issue_url : string;
         labels : Labels.t;
         locked : bool;
-        maintainer_can_modify : bool;
+        maintainer_can_modify : bool option; [@default None]
         merge_commit_sha : string option; [@default None]
         mergeable : bool option; [@default None]
-        mergeable_state : string;
+        mergeable_state : string option; [@default None]
         merged : bool option; [@default None]
         merged_at : string option; [@default None]
         merged_by : Merged_by.t;
@@ -139,7 +139,7 @@ module Pull_request_ = struct
         requested_reviewers : Requested_reviewers.t;
         requested_teams : Requested_teams.t;
         review_comment_url : string;
-        review_comments : int;
+        review_comments : int option; [@default None]
         review_comments_url : string;
         state : State.t;
         statuses_url : string;
@@ -247,21 +247,21 @@ module Pull_request_ = struct
       type t = {
         links_ : Links_.t; [@key "_links"]
         active_lock_reason : string option; [@default None]
-        additions : int;
+        additions : int option; [@default None]
         assignee : Terrat_github_webhooks_user.t option; [@default None]
         assignees : Assignees.t;
         author_association : string;
         auto_merge : Terrat_github_webhooks_auto_merge.t option; [@default None]
         base : Base.t;
         body : string option; [@default None]
-        changed_files : int;
+        changed_files : int option; [@default None]
         closed_at : string option; [@default None]
-        comments : int;
+        comments : int option; [@default None]
         comments_url : string;
-        commits : int;
+        commits : int option; [@default None]
         commits_url : string;
         created_at : string;
-        deletions : int;
+        deletions : int option; [@default None]
         diff_url : string;
         draft : bool;
         head : Head.t;
@@ -270,10 +270,10 @@ module Pull_request_ = struct
         issue_url : string;
         labels : Labels.t;
         locked : bool;
-        maintainer_can_modify : bool;
+        maintainer_can_modify : bool option; [@default None]
         merge_commit_sha : string option; [@default None]
         mergeable : bool option; [@default None]
-        mergeable_state : string;
+        mergeable_state : string option; [@default None]
         merged : bool option; [@default None]
         merged_at : string option; [@default None]
         merged_by : Merged_by.t;
@@ -285,7 +285,7 @@ module Pull_request_ = struct
         requested_reviewers : Requested_reviewers.t;
         requested_teams : Requested_teams.t;
         review_comment_url : string;
-        review_comments : int;
+        review_comments : int option; [@default None]
         review_comments_url : string;
         state : State.t;
         statuses_url : string;

--- a/code/src/terrat_github_webhooks/terrat_github_webhooks_pull_request_reopened.ml
+++ b/code/src/terrat_github_webhooks/terrat_github_webhooks_pull_request_reopened.ml
@@ -101,21 +101,21 @@ module Pull_request_ = struct
       type t = {
         links_ : Links_.t; [@key "_links"]
         active_lock_reason : string option; [@default None]
-        additions : int;
+        additions : int option; [@default None]
         assignee : Terrat_github_webhooks_user.t option; [@default None]
         assignees : Assignees.t;
         author_association : string;
         auto_merge : Terrat_github_webhooks_auto_merge.t option; [@default None]
         base : Base.t;
         body : string option; [@default None]
-        changed_files : int;
+        changed_files : int option; [@default None]
         closed_at : string option; [@default None]
-        comments : int;
+        comments : int option; [@default None]
         comments_url : string;
-        commits : int;
+        commits : int option; [@default None]
         commits_url : string;
         created_at : string;
-        deletions : int;
+        deletions : int option; [@default None]
         diff_url : string;
         draft : bool;
         head : Head.t;
@@ -124,10 +124,10 @@ module Pull_request_ = struct
         issue_url : string;
         labels : Labels.t;
         locked : bool;
-        maintainer_can_modify : bool;
+        maintainer_can_modify : bool option; [@default None]
         merge_commit_sha : string option; [@default None]
         mergeable : bool option; [@default None]
-        mergeable_state : string;
+        mergeable_state : string option; [@default None]
         merged : bool option; [@default None]
         merged_at : string option; [@default None]
         merged_by : Merged_by.t;
@@ -139,7 +139,7 @@ module Pull_request_ = struct
         requested_reviewers : Requested_reviewers.t;
         requested_teams : Requested_teams.t;
         review_comment_url : string;
-        review_comments : int;
+        review_comments : int option; [@default None]
         review_comments_url : string;
         state : State.t;
         statuses_url : string;
@@ -247,21 +247,21 @@ module Pull_request_ = struct
       type t = {
         links_ : Links_.t; [@key "_links"]
         active_lock_reason : string option; [@default None]
-        additions : int;
+        additions : int option; [@default None]
         assignee : Terrat_github_webhooks_user.t option; [@default None]
         assignees : Assignees.t;
         author_association : string;
         auto_merge : Terrat_github_webhooks_auto_merge.t option; [@default None]
         base : Base.t;
         body : string option; [@default None]
-        changed_files : int;
+        changed_files : int option; [@default None]
         closed_at : string option; [@default None]
-        comments : int;
+        comments : int option; [@default None]
         comments_url : string;
-        commits : int;
+        commits : int option; [@default None]
         commits_url : string;
         created_at : string;
-        deletions : int;
+        deletions : int option; [@default None]
         diff_url : string;
         draft : bool;
         head : Head.t;
@@ -270,10 +270,10 @@ module Pull_request_ = struct
         issue_url : string;
         labels : Labels.t;
         locked : bool;
-        maintainer_can_modify : bool;
+        maintainer_can_modify : bool option; [@default None]
         merge_commit_sha : string option; [@default None]
         mergeable : bool option; [@default None]
-        mergeable_state : string;
+        mergeable_state : string option; [@default None]
         merged : bool option; [@default None]
         merged_at : string option; [@default None]
         merged_by : Merged_by.t;
@@ -285,7 +285,7 @@ module Pull_request_ = struct
         requested_reviewers : Requested_reviewers.t;
         requested_teams : Requested_teams.t;
         review_comment_url : string;
-        review_comments : int;
+        review_comments : int option; [@default None]
         review_comments_url : string;
         state : State.t;
         statuses_url : string;

--- a/code/tests/terrat_github_webhooks/tests.ml
+++ b/code/tests/terrat_github_webhooks/tests.ml
@@ -1,14 +1,381 @@
-(* This is a template for testing JSON parsing *)
-let test_simple = Oth.test ~name:"Test simple" (fun _ -> ())
-(* let data = "" in
- * let json = Yojson.Safe.from_string data in
- * match Terrat_github_webhooks.Event.of_yojson json with
- * | Ok _ -> ()
- * | Error err ->
- *     Printf.eprintf "%s\n%!" err;
- *     assert false) *)
+let user_json =
+  {|{
+  "login": "octocat",
+  "id": 1,
+  "node_id": "MDQ6VXNlcjE=",
+  "avatar_url": "https://avatars.githubusercontent.com/u/1?v=4",
+  "gravatar_id": "",
+  "url": "https://api.github.com/users/octocat",
+  "html_url": "https://github.com/octocat",
+  "followers_url": "https://api.github.com/users/octocat/followers",
+  "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+  "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+  "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+  "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+  "organizations_url": "https://api.github.com/users/octocat/orgs",
+  "repos_url": "https://api.github.com/users/octocat/repos",
+  "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+  "received_events_url": "https://api.github.com/users/octocat/received_events",
+  "type": "User",
+  "site_admin": false
+}|}
 
-let test = Oth.parallel [ test_simple ]
+let repo_json =
+  Printf.sprintf
+    {|{
+  "id": 1296269,
+  "node_id": "MDEwOlJlcG9zaXRvcnkxMjk2MjY5",
+  "name": "Hello-World",
+  "full_name": "octocat/Hello-World",
+  "private": false,
+  "owner": %s,
+  "html_url": "https://github.com/octocat/Hello-World",
+  "description": "This your first repo!",
+  "fork": false,
+  "url": "https://api.github.com/repos/octocat/Hello-World",
+  "forks_url": "https://api.github.com/repos/octocat/Hello-World/forks",
+  "keys_url": "https://api.github.com/repos/octocat/Hello-World/keys{/key_id}",
+  "collaborators_url": "https://api.github.com/repos/octocat/Hello-World/collaborators{/collaborator}",
+  "teams_url": "https://api.github.com/repos/octocat/Hello-World/teams",
+  "hooks_url": "https://api.github.com/repos/octocat/Hello-World/hooks",
+  "issue_events_url": "https://api.github.com/repos/octocat/Hello-World/issues/events{/number}",
+  "events_url": "https://api.github.com/repos/octocat/Hello-World/events",
+  "assignees_url": "https://api.github.com/repos/octocat/Hello-World/assignees{/user}",
+  "branches_url": "https://api.github.com/repos/octocat/Hello-World/branches{/branch}",
+  "tags_url": "https://api.github.com/repos/octocat/Hello-World/tags",
+  "blobs_url": "https://api.github.com/repos/octocat/Hello-World/git/blobs{/sha}",
+  "git_tags_url": "https://api.github.com/repos/octocat/Hello-World/git/tags{/sha}",
+  "git_refs_url": "https://api.github.com/repos/octocat/Hello-World/git/refs{/sha}",
+  "trees_url": "https://api.github.com/repos/octocat/Hello-World/git/trees{/sha}",
+  "statuses_url": "https://api.github.com/repos/octocat/Hello-World/statuses/{sha}",
+  "languages_url": "https://api.github.com/repos/octocat/Hello-World/languages",
+  "stargazers_url": "https://api.github.com/repos/octocat/Hello-World/stargazers",
+  "contributors_url": "https://api.github.com/repos/octocat/Hello-World/contributors",
+  "subscribers_url": "https://api.github.com/repos/octocat/Hello-World/subscribers",
+  "subscription_url": "https://api.github.com/repos/octocat/Hello-World/subscription",
+  "commits_url": "https://api.github.com/repos/octocat/Hello-World/commits{/sha}",
+  "git_commits_url": "https://api.github.com/repos/octocat/Hello-World/git/commits{/sha}",
+  "comments_url": "https://api.github.com/repos/octocat/Hello-World/comments{/number}",
+  "issue_comment_url": "https://api.github.com/repos/octocat/Hello-World/issues/comments{/number}",
+  "contents_url": "https://api.github.com/repos/octocat/Hello-World/contents/{+path}",
+  "compare_url": "https://api.github.com/repos/octocat/Hello-World/compare/{base}...{head}",
+  "merges_url": "https://api.github.com/repos/octocat/Hello-World/merges",
+  "archive_url": "https://api.github.com/repos/octocat/Hello-World/{archive_format}{/ref}",
+  "downloads_url": "https://api.github.com/repos/octocat/Hello-World/downloads",
+  "issues_url": "https://api.github.com/repos/octocat/Hello-World/issues{/number}",
+  "pulls_url": "https://api.github.com/repos/octocat/Hello-World/pulls{/number}",
+  "milestones_url": "https://api.github.com/repos/octocat/Hello-World/milestones{/number}",
+  "notifications_url": "https://api.github.com/repos/octocat/Hello-World/notifications{?since,all,participating}",
+  "labels_url": "https://api.github.com/repos/octocat/Hello-World/labels{/name}",
+  "releases_url": "https://api.github.com/repos/octocat/Hello-World/releases{/id}",
+  "deployments_url": "https://api.github.com/repos/octocat/Hello-World/deployments",
+  "created_at": "2011-01-26T19:01:12Z",
+  "updated_at": "2011-01-26T19:14:43Z",
+  "pushed_at": "2011-01-26T19:06:43Z",
+  "git_url": "git://github.com/octocat/Hello-World.git",
+  "ssh_url": "git@github.com:octocat/Hello-World.git",
+  "clone_url": "https://github.com/octocat/Hello-World.git",
+  "svn_url": "https://svn.github.com/octocat/Hello-World",
+  "homepage": "https://github.com",
+  "size": 180,
+  "stargazers_count": 80,
+  "watchers_count": 80,
+  "language": "C",
+  "has_issues": true,
+  "has_projects": true,
+  "has_downloads": true,
+  "has_wiki": true,
+  "has_pages": true,
+  "forks_count": 9,
+  "mirror_url": null,
+  "archived": false,
+  "open_issues_count": 0,
+  "forks": 9,
+  "open_issues": 0,
+  "watchers": 80,
+  "default_branch": "master",
+  "is_template": false,
+  "topics": [],
+  "visibility": "public"
+}|}
+    user_json
+
+let link href = Printf.sprintf {|{"href": "%s"}|} href
+
+let links_json =
+  Printf.sprintf
+    {|{
+  "self": %s,
+  "html": %s,
+  "issue": %s,
+  "comments": %s,
+  "review_comments": %s,
+  "review_comment": %s,
+  "commits": %s,
+  "statuses": %s
+}|}
+    (link "https://api.github.com/repos/octocat/Hello-World/pulls/1")
+    (link "https://github.com/octocat/Hello-World/pull/1")
+    (link "https://api.github.com/repos/octocat/Hello-World/issues/1")
+    (link "https://api.github.com/repos/octocat/Hello-World/issues/1/comments")
+    (link "https://api.github.com/repos/octocat/Hello-World/pulls/1/comments")
+    (link "https://api.github.com/repos/octocat/Hello-World/pulls/comments{/number}")
+    (link "https://api.github.com/repos/octocat/Hello-World/pulls/1/commits")
+    (link "https://api.github.com/repos/octocat/Hello-World/statuses/6dcb09b5b57875f7")
+
+let ref_json label ref_ sha =
+  Printf.sprintf
+    {|{
+  "label": "%s",
+  "ref": "%s",
+  "sha": "%s",
+  "user": %s,
+  "repo": %s
+}|}
+    label
+    ref_
+    sha
+    user_json
+    repo_json
+
+(* A pull_request.synchronize payload where GitHub sends null for fields that
+   are still being computed (additions, deletions, changed_files, commits,
+   comments, review_comments, mergeable_state, maintainer_can_modify). *)
+let synchronize_with_nulls_json =
+  Printf.sprintf
+    {|{
+  "action": "synchronize",
+  "number": 1,
+  "before": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa0",
+  "after": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "pull_request": {
+    "url": "https://api.github.com/repos/octocat/Hello-World/pulls/1",
+    "id": 1,
+    "node_id": "PR_kwDOADYXqs4xxxxx",
+    "html_url": "https://github.com/octocat/Hello-World/pull/1",
+    "diff_url": "https://github.com/octocat/Hello-World/pull/1.diff",
+    "patch_url": "https://github.com/octocat/Hello-World/pull/1.patch",
+    "issue_url": "https://api.github.com/repos/octocat/Hello-World/issues/1",
+    "number": 1,
+    "state": "open",
+    "locked": false,
+    "title": "Amazing new feature",
+    "user": %s,
+    "body": "Please pull in these awesome changes",
+    "created_at": "2024-01-26T19:01:12Z",
+    "updated_at": "2024-01-26T19:01:12Z",
+    "closed_at": null,
+    "merged_at": null,
+    "merge_commit_sha": null,
+    "assignees": [],
+    "requested_reviewers": [],
+    "requested_teams": [],
+    "labels": [],
+    "commits_url": "https://api.github.com/repos/octocat/Hello-World/pulls/1/commits",
+    "review_comments_url": "https://api.github.com/repos/octocat/Hello-World/pulls/1/comments",
+    "review_comment_url": "https://api.github.com/repos/octocat/Hello-World/pulls/comments{/number}",
+    "comments_url": "https://api.github.com/repos/octocat/Hello-World/issues/1/comments",
+    "statuses_url": "https://api.github.com/repos/octocat/Hello-World/statuses/6dcb09b5b57875f7",
+    "head": %s,
+    "base": %s,
+    "_links": %s,
+    "author_association": "OWNER",
+    "active_lock_reason": null,
+    "draft": false,
+    "merged": false,
+    "mergeable": null,
+    "rebaseable": null,
+    "additions": null,
+    "deletions": null,
+    "changed_files": null,
+    "commits": null,
+    "comments": null,
+    "review_comments": null,
+    "mergeable_state": null,
+    "maintainer_can_modify": null
+  },
+  "repository": %s,
+  "installation": {
+    "id": 12345,
+    "node_id": "MDIzOkludGVncmF0aW9uMQ=="
+  },
+  "sender": %s
+}|}
+    user_json
+    (ref_json "octocat:new-feature" "new-feature" "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
+    (ref_json "octocat:master" "master" "e7e4f4d38f100ff01ee488e8ff77dd2b09f95eef")
+    links_json
+    repo_json
+    user_json
+
+(* Same payload but with the fields present (non-null) to verify normal parsing
+   still works. *)
+let synchronize_with_values_json =
+  Printf.sprintf
+    {|{
+  "action": "synchronize",
+  "number": 1,
+  "before": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa0",
+  "after": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "pull_request": {
+    "url": "https://api.github.com/repos/octocat/Hello-World/pulls/1",
+    "id": 1,
+    "node_id": "PR_kwDOADYXqs4xxxxx",
+    "html_url": "https://github.com/octocat/Hello-World/pull/1",
+    "diff_url": "https://github.com/octocat/Hello-World/pull/1.diff",
+    "patch_url": "https://github.com/octocat/Hello-World/pull/1.patch",
+    "issue_url": "https://api.github.com/repos/octocat/Hello-World/issues/1",
+    "number": 1,
+    "state": "open",
+    "locked": false,
+    "title": "Amazing new feature",
+    "user": %s,
+    "body": "Please pull in these awesome changes",
+    "created_at": "2024-01-26T19:01:12Z",
+    "updated_at": "2024-01-26T19:01:12Z",
+    "closed_at": null,
+    "merged_at": null,
+    "merge_commit_sha": null,
+    "assignees": [],
+    "requested_reviewers": [],
+    "requested_teams": [],
+    "labels": [],
+    "commits_url": "https://api.github.com/repos/octocat/Hello-World/pulls/1/commits",
+    "review_comments_url": "https://api.github.com/repos/octocat/Hello-World/pulls/1/comments",
+    "review_comment_url": "https://api.github.com/repos/octocat/Hello-World/pulls/comments{/number}",
+    "comments_url": "https://api.github.com/repos/octocat/Hello-World/issues/1/comments",
+    "statuses_url": "https://api.github.com/repos/octocat/Hello-World/statuses/6dcb09b5b57875f7",
+    "head": %s,
+    "base": %s,
+    "_links": %s,
+    "author_association": "OWNER",
+    "active_lock_reason": null,
+    "draft": false,
+    "merged": false,
+    "mergeable": true,
+    "rebaseable": true,
+    "additions": 10,
+    "deletions": 5,
+    "changed_files": 3,
+    "commits": 2,
+    "comments": 0,
+    "review_comments": 0,
+    "mergeable_state": "clean",
+    "maintainer_can_modify": true
+  },
+  "repository": %s,
+  "installation": {
+    "id": 12345,
+    "node_id": "MDIzOkludGVncmF0aW9uMQ=="
+  },
+  "sender": %s
+}|}
+    user_json
+    (ref_json "octocat:new-feature" "new-feature" "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
+    (ref_json "octocat:master" "master" "e7e4f4d38f100ff01ee488e8ff77dd2b09f95eef")
+    links_json
+    repo_json
+    user_json
+
+(* A pull_request.synchronize payload where the nullable fields are entirely
+   absent from the JSON (not present at all, not even as null). *)
+let synchronize_with_missing_fields_json =
+  Printf.sprintf
+    {|{
+  "action": "synchronize",
+  "number": 1,
+  "before": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa0",
+  "after": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "pull_request": {
+    "url": "https://api.github.com/repos/octocat/Hello-World/pulls/1",
+    "id": 1,
+    "node_id": "PR_kwDOADYXqs4xxxxx",
+    "html_url": "https://github.com/octocat/Hello-World/pull/1",
+    "diff_url": "https://github.com/octocat/Hello-World/pull/1.diff",
+    "patch_url": "https://github.com/octocat/Hello-World/pull/1.patch",
+    "issue_url": "https://api.github.com/repos/octocat/Hello-World/issues/1",
+    "number": 1,
+    "state": "open",
+    "locked": false,
+    "title": "Amazing new feature",
+    "user": %s,
+    "body": "Please pull in these awesome changes",
+    "created_at": "2024-01-26T19:01:12Z",
+    "updated_at": "2024-01-26T19:01:12Z",
+    "closed_at": null,
+    "merged_at": null,
+    "merge_commit_sha": null,
+    "assignees": [],
+    "requested_reviewers": [],
+    "requested_teams": [],
+    "labels": [],
+    "commits_url": "https://api.github.com/repos/octocat/Hello-World/pulls/1/commits",
+    "review_comments_url": "https://api.github.com/repos/octocat/Hello-World/pulls/1/comments",
+    "review_comment_url": "https://api.github.com/repos/octocat/Hello-World/pulls/comments{/number}",
+    "comments_url": "https://api.github.com/repos/octocat/Hello-World/issues/1/comments",
+    "statuses_url": "https://api.github.com/repos/octocat/Hello-World/statuses/6dcb09b5b57875f7",
+    "head": %s,
+    "base": %s,
+    "_links": %s,
+    "author_association": "OWNER",
+    "active_lock_reason": null,
+    "draft": false,
+    "merged": false,
+    "mergeable": null,
+    "rebaseable": null
+  },
+  "repository": %s,
+  "installation": {
+    "id": 12345,
+    "node_id": "MDIzOkludGVncmF0aW9uMQ=="
+  },
+  "sender": %s
+}|}
+    user_json
+    (ref_json "octocat:new-feature" "new-feature" "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
+    (ref_json "octocat:master" "master" "e7e4f4d38f100ff01ee488e8ff77dd2b09f95eef")
+    links_json
+    repo_json
+    user_json
+
+let parse_event data =
+  let json = Yojson.Safe.from_string data in
+  Terrat_github_webhooks.Event.of_yojson json
+
+let test_synchronize_with_null_fields =
+  Oth.test ~name:"Synchronize with null fields" (fun _ ->
+      match parse_event synchronize_with_nulls_json with
+      | Ok (Terrat_github_webhooks.Event.Pull_request_event _) -> ()
+      | Ok _ -> assert false
+      | Error err ->
+          Printf.eprintf "Parse error: %s\n%!" err;
+          assert false)
+
+let test_synchronize_with_values =
+  Oth.test ~name:"Synchronize with non-null fields" (fun _ ->
+      match parse_event synchronize_with_values_json with
+      | Ok (Terrat_github_webhooks.Event.Pull_request_event _) -> ()
+      | Ok _ -> assert false
+      | Error err ->
+          Printf.eprintf "Parse error: %s\n%!" err;
+          assert false)
+
+let test_synchronize_with_missing_fields =
+  Oth.test ~name:"Synchronize with missing fields" (fun _ ->
+      match parse_event synchronize_with_missing_fields_json with
+      | Ok (Terrat_github_webhooks.Event.Pull_request_event _) -> ()
+      | Ok _ -> assert false
+      | Error err ->
+          Printf.eprintf "Parse error: %s\n%!" err;
+          assert false)
+
+let test =
+  Oth.parallel
+    [
+      test_synchronize_with_null_fields;
+      test_synchronize_with_values;
+      test_synchronize_with_missing_fields;
+    ]
 
 let () =
   Random.self_init ();


### PR DESCRIPTION
GitHub sends null values for several pull_request fields (additions, deletions, changed_files, commits, comments, review_comments, mergeable_state, maintainer_can_modify) during synchronize events because diff stats are computed asynchronously after a push. The terrat webhook schema marked these as required non-nullable, causing a oneOf parse error.

Update the schema and generated types to make these 8 fields nullable and optional, matching the GitHub official API schema used by githubc2. Add tests covering synchronize payloads with null, non-null, and missing fields.

I am not an experienced rust developer so Claude wrote most of the code, feel free to make any relevant changes.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (explain):

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/terrateamio/terrateam/blob/main/CONTRIBUTING.md)
- [x] The pull request title follows this format:
      `ISSUE_NUMBER ACTION_TYPE Short description` (e.g., `123 ADD Feature description`)
- [x] I have added tests and documentation (if applicable)
- [x] My changes generate no new warnings/errors and do not break existing functionality

## Additional context (optional)

<!-- Add any additional context here, e.g., screenshots, dependencies, etc. -->
