### PR TITLE
fix(nginx): expose /metrics endpoint through reverse proxy

### DIFF
--- a/docker/terrat/nginx.conf.template
+++ b/docker/terrat/nginx.conf.template
@@ -94,6 +94,11 @@ http {
             proxy_set_header X-Forwarded-For $remote_addr;
         }
 
+        location /metrics {
+            proxy_pass http://127.0.0.1:8180;
+            proxy_set_header X-Forwarded-For $remote_addr;
+        }
+
         location /nginx_status {
             stub_status on;
             access_log off;


### PR DESCRIPTION
## Summary

- The Terrateam backend exposes Prometheus metrics at `/metrics` on port 8180, and the [observability docs](https://docs.terrateam.io/self-hosted/observability-metrics) reference `http://<terrateam-host>/metrics` as the scrape target
- However, the nginx reverse proxy in `docker/terrat/nginx.conf.template` has no `location /metrics` block, so requests fall through to the root `/` catch-all and return the SPA HTML instead of metrics data
- Add a `location /metrics` block that proxies to the backend, consistent with the existing `/health` endpoint

## Test plan

- [ ] Build the Docker image with the updated nginx config
- [ ] Verify `curl http://localhost:8080/metrics` returns Prometheus metrics instead of HTML
- [ ] Verify existing endpoints (`/api`, `/health`, `/nginx_status`) still work