### PR TITLE
#832 ADD OSSF Scorecard workflow

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,49 @@
+name: scorecard
+
+on:
+  push:
+    branches:
+      - main
+  schedule:
+    # Run weekly on Saturdays at 01:30 UTC
+    - cron: "30 1 * * 6"
+
+# Scorecard requires read-all at the workflow level when publishing results.
+# Job-level permissions below grant the additional writes needed.
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-22.04
+
+    permissions:
+      # Upload SARIF results to Code Scanning dashboard
+      security-events: write
+      # Publish results to OpenSSF API (requires OIDC token)
+      id-token: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run Scorecard analysis
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload to code-scanning
+        uses: github/codeql-action/upload-sarif@b20883b0cd1f46c72ae0ba6d1090936928f9fa30 # v4.32.0
+        with:
+          sarif_file: results.sarif


### PR DESCRIPTION
Adds an [OpenSSF Scorecard](https://securityscorecards.dev/) workflow that runs weekly and on pushes to main.

## What It Does

Scorecard evaluates the repo against a set of security best practices — branch protection, dependency pinning, CI permissions, signed releases, etc. — and publishes results to:
- GitHub's Code Scanning dashboard (SARIF)
- The public OpenSSF API (via OIDC token)

## Changes

- `.github/workflows/scorecard.yml` — 49 lines, single job
- All actions pinned to full commit SHAs (verified against tagged releases):
  - `actions/checkout@v6.0.2`
  - `ossf/scorecard-action@v2.4.3`
  - `actions/upload-artifact@v6.0.0`
  - `github/codeql-action/upload-sarif@v4.32.0`
- Runs on `ubuntu-22.04` with minimal permissions (`read-all` at workflow level, `security-events: write` + `id-token: write` at job level)
- Weekly schedule: Saturdays 01:30 UTC

## Why

Resolves #832. Scorecard is a lightweight way to surface security posture improvements and gives users confidence in the project's supply chain hygiene. It's commonly adopted by CNCF and OpenSSF member projects.

I'm new to the Terrateam community — happy to adjust anything about the configuration if there's a preferred approach.