### PR TITLE
Fix: Add missed TERRAT_API_BASE into docker compose configuration

### DIFF
--- a/docker/terrat/docker-compose.yml
+++ b/docker/terrat/docker-compose.yml
@@ -66,6 +66,7 @@ services:
       # SELF_HOSTED_INFRACOST_API_KEY: "REPLACE_WITH_32_CHARACTER_STRING"  # Must match cloud-pricing-api key
       TERRAT_UI_BASE: "${TERRAT_UI_BASE}"
       TERRAT_WEB_BASE_URL: "${TERRAT_WEB_BASE_URL}"
+      TERRAT_API_BASE: "${TERRAT_API_BASE}"
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
       interval: 3s


### PR DESCRIPTION
## Description

Right now we are missing TERRAT_API_BASE for docker compose configuration. It also missed from the setup UI, but probably can be fixed within another PR. 

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (explain):

## Checklist

- [ ] I have read the [contributing guidelines](https://github.com/terrateamio/terrateam/blob/main/CONTRIBUTING.md)
- [ ] The pull request title follows this format:
      `ISSUE_NUMBER ACTION_TYPE Short description` (e.g., `123 ADD Feature description`)
- [ ] I have added tests and documentation (if applicable)
- [ ] My changes generate no new warnings/errors and do not break existing functionality

## Additional context (optional)

<!-- Add any additional context here, e.g., screenshots, dependencies, etc. -->
