### PR TITLE
#1314 REFACTOR github installation query resiliency

### DIFF
--- a/code/src/iris/src/App.svelte
+++ b/code/src/iris/src/App.svelte
@@ -2,19 +2,19 @@
   import { onMount } from 'svelte';
   import router from 'svelte-spa-router';
   import { isAuthenticated, isLoading, getCurrentUser, redirectToIntendedUrl } from './lib/auth';
-  import { api, isApiError } from './lib/api';
+  import { api } from './lib/api';
   import {
     installations,
     selectedInstallation,
     installationsLoading,
     installationsError,
-    defaultInstallationId,
+    installationsInitialized,
     theme,
     hasVisitedBefore,
     markAsVisited,
-    currentVCSProvider,
     serverConfig
   } from './lib/stores';
+  import { loadInstallations } from './lib/installations';
   import { getMaintenanceConfig } from './lib/utils/maintenance';
   import MaintenanceMode from './lib/MaintenanceMode.svelte';
   import Login from './lib/Login.svelte';
@@ -88,38 +88,39 @@
   
   // Auto-redirect authenticated users based on intended URL or whether they've visited before
   // Only redirect when we have all the data we need (auth + installations loaded)
-  $: if (!maintenanceConfig.isMaintenanceMode && $isAuthenticated && !$isLoading && installationsInitialized && !$installationsLoading && (window.location.hash === '#/' || window.location.hash === '')) {
-    
+  $: if (!maintenanceConfig.isMaintenanceMode && $isAuthenticated && !$isLoading && $installationsInitialized && !$installationsLoading && (window.location.hash === '#/' || window.location.hash === '')) {
+
     // First priority: Check for stored intended URL
     const redirectedToIntended = redirectToIntendedUrl();
-    if (redirectedToIntended) {
-    } else {
-      // Fallback: Based on whether they've visited before  
-      // We now know installations are loaded, so we can make the decision
-      if ($installations.length === 0) {
-        // User has no installations, redirect to getting started regardless
+    if (!redirectedToIntended) {
+      // Fallback: Based on whether they've visited before
+      if ($installations.length > 0) {
+        // User has installations — route to the selected one's dashboard.
+        if ($selectedInstallation) {
+          if ($hasVisitedBefore) {
+            window.location.hash = `#/i/${$selectedInstallation.id}/dashboard`;
+          } else {
+            window.location.hash = '#/getting-started';
+            markAsVisited(); // Mark as visited when they first see getting started
+          }
+        }
+        // else: installations exist but none selected yet - wait for selection to complete
+      } else if (!$installationsError) {
+        // Definitive empty result (successful fetch, genuinely no installations):
+        // send the user to getting started / demo mode.
         window.location.hash = '#/getting-started';
         if (!$hasVisitedBefore) {
           markAsVisited();
         }
-      } else if ($selectedInstallation) {
-        // User has installations and one is selected
-        if ($hasVisitedBefore) {
-          window.location.hash = `#/i/${$selectedInstallation.id}/dashboard`;
-        } else {
-          window.location.hash = '#/getting-started';
-          markAsVisited(); // Mark as visited when they first see getting started
-        }
-      } else {
-        // Installations exist but none selected yet - wait for selection to complete
       }
+      // else: failed to load installations and nothing is cached — stay at root;
+      // AuthenticationLoader surfaces the error with a retry instead of demo mode.
     }
   }
   
-  // Load installations when user is authenticated (only once)
-  let installationsInitialized = false;
-  $: if (!maintenanceConfig.isMaintenanceMode && $isAuthenticated && !$isLoading && !installationsInitialized) {
-    installationsInitialized = true;
+  // Load installations when user is authenticated. loadInstallations() guards
+  // against duplicate loads and marks installationsInitialized internally.
+  $: if (!maintenanceConfig.isMaintenanceMode && $isAuthenticated && !$isLoading && !$installationsInitialized) {
     loadInstallations();
   }
 
@@ -133,56 +134,6 @@
     }
   }
 
-  async function loadInstallations() {
-    if ($installationsLoading) return;
-    
-    installationsLoading.set(true);
-    installationsError.set(null);
-    
-    try {
-      const provider = $currentVCSProvider;
-      const response = await api.getUserInstallations(provider);
-      
-      if (response && response.installations) {
-        installations.set(response.installations);
-        
-        // Auto-select installation based on default setting or first available
-        if (response.installations.length > 0 && !$selectedInstallation) {
-          let installationToSelect = response.installations[0];
-          
-          // Try to find the default installation if one is set
-          if ($defaultInstallationId) {
-            const defaultInstallation = response.installations.find(inst => inst.id === $defaultInstallationId);
-            if (defaultInstallation) {
-              installationToSelect = defaultInstallation;
-            } else {
-            }
-          } else {
-          }
-          
-          selectedInstallation.set(installationToSelect);
-        }
-      } else {
-        console.warn('No installations found in response:', response);
-        installations.set([]);
-      }
-    } catch (err) {
-      console.error('Error loading installations:', err);
-      
-      // For GitLab, if we get a 404, treat it as "no installations" rather than an error
-      // This handles the case where the GitLab installations endpoint isn't implemented yet
-      if ($currentVCSProvider === 'gitlab' && isApiError(err) && err.status === 404) {
-        installations.set([]);
-        installationsError.set(null);
-      } else {
-        installationsError.set('Failed to load installations');
-        installations.set([]);
-      }
-    } finally {
-      installationsLoading.set(false);
-    }
-  }
-  
   // Handle legacy URL redirects
   function handleLegacyUrlRedirect() {
     const path = window.location.pathname;

--- a/code/src/iris/src/lib/Repositories.svelte
+++ b/code/src/iris/src/lib/Repositories.svelte
@@ -342,7 +342,7 @@
       <LoadingSpinner size="lg" />
       <span class="ml-3 text-[var(--sg-text-muted)]">Loading {terminology.organizations}...</span>
     </div>
-  {:else if $installationsError}
+  {:else if $installationsError && $installations.length === 0}
     <ErrorMessage type="error" message="Failed to load {terminology.organizations}: {$installationsError}" />
   {:else if $installations.length === 0}
     <Card padding="lg" class="text-center">

--- a/code/src/iris/src/lib/auth.ts
+++ b/code/src/iris/src/lib/auth.ts
@@ -237,6 +237,25 @@ export async function getCurrentUser(): Promise<User | null> {
 }
 
 export async function logout(): Promise<void> {
+  // Clear cached installation state first so a different user signing in on a
+  // shared browser can never see the previous user's last-known-good list.
+  try {
+    const {
+      installations,
+      selectedInstallation,
+      installationsError,
+      installationsInitialized,
+      clearInstallationsCache
+    } = await import('./stores');
+    installations.set([]);
+    selectedInstallation.set(null);
+    installationsError.set(null);
+    installationsInitialized.set(false);
+    clearInstallationsCache();
+  } catch (e) {
+    console.warn('Failed to clear installation state on logout:', e);
+  }
+
   try {
     const response = await fetch(`${API_BASE}/api/v1/logout`, {
       method: 'POST',

--- a/code/src/iris/src/lib/components/layout/AuthenticationLoader.svelte
+++ b/code/src/iris/src/lib/components/layout/AuthenticationLoader.svelte
@@ -1,17 +1,51 @@
 <script lang="ts">
   import LoadingSpinner from '../ui/LoadingSpinner.svelte';
+  import { installations, installationsError, installationsLoading } from '../../stores';
+  import { loadInstallations } from '../../installations';
+
+  // Only treat this as a hard error when the load failed AND we have no
+  // last-known-good installations to fall back on. With a cache present we
+  // never block here — App.svelte routes the user straight to their workspace.
+  $: showError = !!$installationsError && !$installationsLoading && $installations.length === 0;
+
+  function retry(): void {
+    loadInstallations(true);
+  }
 </script>
 
-<!-- Authentication Loading Screen -->
-<div class="min-h-screen bg-brand-bg flex items-center justify-center">
-  <div class="text-center">
-    <div class="inline-flex items-center justify-center w-16 h-16 rounded-full mb-6 brand-icon-bg">
-      <svg class="w-8 h-8 text-[var(--sg-text)]" fill="currentColor" viewBox="0 0 24 24">
-        <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"/>
-      </svg>
+{#if showError}
+  <!-- Failed to load installations with nothing cached -->
+  <div class="min-h-screen bg-brand-bg flex items-center justify-center">
+    <div class="text-center max-w-md px-6">
+      <div class="inline-flex items-center justify-center w-16 h-16 rounded-full mb-6 brand-icon-bg">
+        <svg class="w-8 h-8 text-[var(--sg-text)]" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01M5.07 19h13.86c1.54 0 2.5-1.67 1.73-3L13.73 4c-.77-1.33-2.69-1.33-3.46 0L3.34 16c-.77 1.33.19 3 1.73 3z" />
+        </svg>
+      </div>
+      <h2 class="text-2xl font-semibold text-[var(--sg-text)] mb-4">Couldn't load your installations</h2>
+      <p class="text-[var(--sg-text-muted)] mb-6">
+        We couldn't reach Terrateam to load your organizations. This is usually temporary — please try again.
+      </p>
+      <button
+        on:click={retry}
+        class="px-4 py-2 bg-[var(--sg-accent)] text-white rounded-md hover:opacity-90 transition-opacity"
+      >
+        Try again
+      </button>
     </div>
-    <h2 class="text-2xl font-semibold text-[var(--sg-text)] mb-4">Setting up your workspace...</h2>
-    <LoadingSpinner size="md" />
-    <p class="text-[var(--sg-text-muted)] mt-4">Loading your installations and preferences</p>
   </div>
-</div>
+{:else}
+  <!-- Authentication Loading Screen -->
+  <div class="min-h-screen bg-brand-bg flex items-center justify-center">
+    <div class="text-center">
+      <div class="inline-flex items-center justify-center w-16 h-16 rounded-full mb-6 brand-icon-bg">
+        <svg class="w-8 h-8 text-[var(--sg-text)]" fill="currentColor" viewBox="0 0 24 24">
+          <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"/>
+        </svg>
+      </div>
+      <h2 class="text-2xl font-semibold text-[var(--sg-text)] mb-4">Setting up your workspace...</h2>
+      <LoadingSpinner size="md" />
+      <p class="text-[var(--sg-text-muted)] mt-4">Loading your installations and preferences</p>
+    </div>
+  </div>
+{/if}

--- a/code/src/iris/src/lib/components/layout/PageLayout.svelte
+++ b/code/src/iris/src/lib/components/layout/PageLayout.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { isAuthenticated, storeIntendedUrl } from '../../auth';
-  import { installations, installationsLoading, currentVCSProvider } from '../../stores';
+  import { installations, installationsLoading, installationsError, currentVCSProvider } from '../../stores';
   import Sidebar from '../../Sidebar.svelte';
   import { VCS_PROVIDERS } from '../../vcs/providers';
 
@@ -86,7 +86,7 @@
     {/if}
 
     <!-- Getting Started Banner (shown when no installations are connected) -->
-    {#if !$installationsLoading && $installations.length === 0 && activeItem !== 'getting-started' && activeItem !== 'login'}
+    {#if !$installationsLoading && !$installationsError && $installations.length === 0 && activeItem !== 'getting-started' && activeItem !== 'login'}
       <div class="bg-[var(--sg-success-bg)] border-b border-[var(--sg-success)]">
         <div class="px-4 md:px-6 py-3">
           <div class="flex items-center justify-between">

--- a/code/src/iris/src/lib/installations.ts
+++ b/code/src/iris/src/lib/installations.ts
@@ -1,0 +1,96 @@
+import { get } from 'svelte/store';
+import { api, isApiError } from './api';
+import {
+  installations,
+  selectedInstallation,
+  installationsLoading,
+  installationsError,
+  installationsInitialized,
+  defaultInstallationId,
+  currentVCSProvider,
+  cacheInstallations,
+  clearInstallationsCache
+} from './stores';
+import type { Installation } from './types';
+
+/**
+ * Reconcile the selected installation against a freshly-fetched list.
+ *
+ * Preference order: keep the currently-selected installation if it still
+ * exists (so a refresh updates its metadata without changing the selection),
+ * otherwise the user's default, otherwise the first available.
+ */
+function reconcileSelectedInstallation(list: Installation[]): void {
+  if (list.length === 0) {
+    selectedInstallation.set(null);
+    return;
+  }
+
+  const current = get(selectedInstallation);
+  if (current) {
+    const stillPresent = list.find((i) => i.id === current.id);
+    if (stillPresent) {
+      selectedInstallation.set(stillPresent);
+      return;
+    }
+  }
+
+  const defaultId = get(defaultInstallationId);
+  const next = (defaultId && list.find((i) => i.id === defaultId)) || list[0];
+  selectedInstallation.set(next);
+}
+
+/**
+ * Load the user's installations.
+ *
+ * Key invariant: only a *successful* response is authoritative. A success
+ * (even an empty list — e.g. the app was genuinely uninstalled) overwrites the
+ * in-memory list and the last-known-good cache. Any error leaves the existing
+ * (cached) installations in place and only sets installationsError, so a
+ * transient failure can never masquerade as "no installations" / demo mode.
+ *
+ * Pass force=true to retry after a failure (bypasses the once-per-session guard).
+ */
+export async function loadInstallations(force = false): Promise<void> {
+  if (get(installationsLoading)) return;
+  if (get(installationsInitialized) && !force) return;
+
+  installationsInitialized.set(true);
+  installationsLoading.set(true);
+  installationsError.set(null);
+
+  try {
+    const provider = get(currentVCSProvider);
+    const response = await api.getUserInstallations(provider);
+
+    if (response && response.installations && response.installations.length > 0) {
+      // Authoritative, non-empty result — update the list and the cache.
+      installations.set(response.installations);
+      cacheInstallations(response.installations);
+      reconcileSelectedInstallation(response.installations);
+    } else {
+      // Authoritative empty result — the user genuinely has no installations.
+      // Clear the cache so demo mode is shown now and on the next visit.
+      installations.set([]);
+      clearInstallationsCache();
+      selectedInstallation.set(null);
+    }
+  } catch (err) {
+    console.error('Error loading installations:', err);
+
+    if (get(currentVCSProvider) === 'gitlab' && isApiError(err) && err.status === 404) {
+      // The GitLab installations endpoint isn't implemented yet — treat a 404
+      // as a definitive "no installations" rather than an error.
+      installations.set([]);
+      clearInstallationsCache();
+      selectedInstallation.set(null);
+      installationsError.set(null);
+    } else {
+      // Transient/real error: keep the last-known-good installations in place
+      // (do NOT clear the list) so we never fall back to demo mode on a blip.
+      installationsError.set('Failed to load installations');
+    }
+  } finally {
+    installationsLoading.set(false);
+  }
+}

--- a/code/src/iris/src/lib/stores.ts
+++ b/code/src/iris/src/lib/stores.ts
@@ -11,10 +11,79 @@ export const availableProviders: Writable<VCSProvider[]> = writable(['github', '
 export const serverConfig: Writable<ServerConfig> = writable();
 
 // Organization/installation state
-export const installations: Writable<Installation[]> = writable([]);
-export const selectedInstallation: Writable<Installation | null> = writable(null);
+//
+// Installations are hydrated from a last-known-good cache so that a transient
+// failure to reach the installations endpoint does not drop the user into
+// "demo mode" (which keys off an empty installations list). Only a *successful*
+// fetch is authoritative and may overwrite this cache — see loadInstallations()
+// in ./installations.
+const INSTALLATIONS_CACHE_KEY = 'installations-cache';
+
+function loadCachedInstallations(): Installation[] {
+  if (typeof window === 'undefined') return [];
+  try {
+    const cached = localStorage.getItem(INSTALLATIONS_CACHE_KEY);
+    if (!cached) return [];
+    const parsed = JSON.parse(cached);
+    // Tolerate both the current `{ installations, timestamp }` shape and a
+    // legacy bare array.
+    const list = Array.isArray(parsed) ? parsed : parsed?.installations;
+    if (Array.isArray(list) && list.every((i) => i && typeof i.id === 'string')) {
+      return list as Installation[];
+    }
+  } catch (e) {
+    console.warn('Failed to load installations from cache:', e);
+  }
+  return [];
+}
+
+function resolveInitialSelectedInstallation(list: Installation[]): Installation | null {
+  if (list.length === 0) return null;
+  try {
+    const defaultId = localStorage.getItem('defaultInstallationId');
+    if (defaultId) {
+      const match = list.find((i) => i.id === defaultId);
+      if (match) return match;
+    }
+  } catch (e) {
+    console.warn('Failed to resolve default installation:', e);
+  }
+  return list[0];
+}
+
+// Persist the last successfully-fetched installations as the last-known-good set.
+export function cacheInstallations(list: Installation[]): void {
+  if (typeof window === 'undefined') return;
+  try {
+    localStorage.setItem(
+      INSTALLATIONS_CACHE_KEY,
+      JSON.stringify({ installations: list, timestamp: Date.now() })
+    );
+  } catch (e) {
+    console.warn('Failed to cache installations:', e);
+  }
+}
+
+export function clearInstallationsCache(): void {
+  if (typeof window === 'undefined') return;
+  try {
+    localStorage.removeItem(INSTALLATIONS_CACHE_KEY);
+  } catch (e) {
+    console.warn('Failed to clear installations cache:', e);
+  }
+}
+
+const initialInstallations = loadCachedInstallations();
+
+export const installations: Writable<Installation[]> = writable(initialInstallations);
+export const selectedInstallation: Writable<Installation | null> = writable(
+  resolveInitialSelectedInstallation(initialInstallations)
+);
 export const installationsLoading: Writable<boolean> = writable(false);
 export const installationsError: Writable<string | null> = writable(null);
+// Whether installations have been fetched at least once this session. Drives the
+// root routing decision and guards against duplicate concurrent loads.
+export const installationsInitialized: Writable<boolean> = writable(false);
 
 // Global repository cache for the current installation with persistence
 function createPersistentRepositoryCache() {

--- a/code/src/terrat_vcs_service_github/sql/select_installations_for_user.sql
+++ b/code/src/terrat_vcs_service_github/sql/select_installations_for_user.sql
@@ -6,7 +6,10 @@ select
   to_char(gi.trial_ends_at, 'YYYY-MM-DD"T"HH24:MI:SS"Z"') as trial_ends_at,
   tiers.name,
   tiers.features
-from github_installations as gi
+from github_user_installations2 as gui
+inner join github_installations as gi
+      on gi.id = gui.installation_id
 inner join tiers
       on tiers.id = gi.tier
-where gi.id = ANY($installation_ids)
+where gui.user_id = $user_id
+order by gi.login

--- a/code/src/terrat_vcs_service_github/sql/upsert_user_installations.sql
+++ b/code/src/terrat_vcs_service_github/sql/upsert_user_installations.sql
@@ -1,12 +1,22 @@
+-- Record the installations a user belongs to, keyed off the authoritative list
+-- GitHub reported for this user ($installation_ids).
+--
+-- This is intentionally ADDITIVE ONLY (mirrors the repository refresh): it never
+-- deletes memberships. An empty or partial $installation_ids (transient GitHub
+-- error, eventual consistency, or the brand-new-install webhook race) must never
+-- be able to wipe a user's existing membership — doing so previously dropped the
+-- user into demo mode and emptied every user-scoped view. Pruning memberships for
+-- orgs a user has genuinely left is handled out-of-band, not on this hot path.
+--
+-- The inner join on github_installations is required by the
+-- github_user_installations2.installation_id foreign key: we can only record
+-- membership for an installation whose row already exists locally (created by the
+-- installation webhook).
 with
 all_installation_ids as (
     select t.id from unnest($installation_ids) as t(id)
     inner join github_installations as gi
         on gi.id = t.id
-),
-deleted as (
-    delete from github_user_installations2
-    where user_id = $user_id and not exists (select id from all_installation_ids)
 ),
 inserted as (
     insert into github_user_installations2 (user_id, installation_id)

--- a/code/src/terrat_vcs_service_github/terrat_vcs_service_github_ep_user.ml
+++ b/code/src/terrat_vcs_service_github/terrat_vcs_service_github_ep_user.ml
@@ -77,7 +77,7 @@ module Installations = struct
       end in
       CCFun.(P.of_yojson %> CCResult.to_opt)
 
-    let select_installations () =
+    let select_installations_for_user () =
       Pgsql_io.Typed_sql.(
         sql
         //
@@ -101,8 +101,8 @@ module Installations = struct
         //
         (* tier features *)
         Ret.u Ret.json tier_features
-        /^ read [%blob "sql/select_user_installations.sql"]
-        /% Var.(array (bigint "installation_ids")))
+        /^ read [%blob "sql/select_installations_for_user.sql"]
+        /% Var.(uuid "user_id"))
 
     let upsert_user_installations () =
       Pgsql_io.Typed_sql.(
@@ -121,27 +121,49 @@ module Installations = struct
         /% Var.(array (bigint "installation_ids")))
   end
 
-  let get' config storage user =
-    let open Abbs_future_combinators.Infix_result_monad in
-    Terrat_vcs_service_github_user.get_token config storage user
-    >>= fun token ->
-    Terrat_github.with_client
-      (Terrat_vcs_service_github_provider.Api.Config.vcs_config config)
-      (`Bearer token)
-      Terrat_github.get_user_installations
-    >>= fun installations ->
+  (* Best-effort refresh of the user's installation membership from GitHub. Never
+     raises on a GitHub/token/db error — instead it reports how many installations
+     GitHub attributed to this user, so the caller can tell three situations apart:
+       - Some n (n > 0) : GitHub is reachable and the user has installations
+       - Some 0         : GitHub is reachable and the user genuinely has none
+       - None           : we could not reach GitHub (serve cached membership)
+     The membership upsert is additive (see sql/upsert_user_installations.sql), so
+     a transient failure or empty response can never erase a user's memberships. *)
+  let refresh_membership request_id config storage user =
+    let open Abb.Future.Infix_monad in
+    (let open Abbs_future_combinators.Infix_result_monad in
+     Terrat_vcs_service_github_user.get_token config storage user
+     >>= fun token ->
+     Terrat_github.with_client
+       (Terrat_vcs_service_github_provider.Api.Config.vcs_config config)
+       (`Bearer token)
+       Terrat_github.get_user_installations
+     >>= fun installations ->
+     Pgsql_pool.with_conn storage ~f:(fun db ->
+         let module I = Githubc2_components.Installation in
+         Pgsql_io.Prepared_stmt.fetch
+           db
+           ~f:(fun _ _ _ -> ())
+           (Sql.upsert_user_installations ())
+           (Terrat_user.id user)
+           (CCList.map
+              (fun { I.primary = { I.Primary.id; _ }; _ } -> Int64.of_int id)
+              installations))
+     >>= fun _ -> Abb.Future.return (Ok (CCList.length installations)))
+    >>= function
+    | Ok n -> Abb.Future.return (Some n)
+    | Error _ ->
+        Logs.warn (fun m ->
+            m
+              "%s : INSTALLATIONS : MEMBERSHIP_REFRESH_FAILED : serving cached membership"
+              request_id);
+        Abb.Future.return None
+
+  let select_user_installations storage user =
     Pgsql_pool.with_conn storage ~f:(fun db ->
-        let module I = Githubc2_components.Installation in
         Pgsql_io.Prepared_stmt.fetch
           db
-          ~f:(fun _ _ _ -> ())
-          (Sql.upsert_user_installations ())
-          (Terrat_user.id user)
-          (CCList.map (fun { I.primary = { I.Primary.id; _ }; _ } -> Int64.of_int id) installations)
-        >>= fun _ ->
-        Pgsql_io.Prepared_stmt.fetch
-          db
-          (Sql.select_installations ())
+          (Sql.select_installations_for_user ())
           ~f:(fun id name account_status created_at trial_ends_at tier_name tier_features ->
             let module I = Terrat_api_components.Installation in
             let module T = Terrat_api_components.Tier in
@@ -158,7 +180,29 @@ module Installations = struct
               }
             in
             { I.id = CCInt64.to_string id; name; account_status; created_at; trial_ends_at; tier })
-          (CCList.map (fun I.{ primary = Primary.{ id; _ }; _ } -> Int64.of_int id) installations))
+          (Terrat_user.id user))
+
+  let get' request_id config storage user =
+    let open Abb.Future.Infix_monad in
+    (* Refresh from GitHub best-effort, then serve the authoritative list from the
+       local database. *)
+    refresh_membership request_id config storage user
+    >>= fun github_count ->
+    select_user_installations storage user
+    >>= function
+    | Ok (_ :: _ as installations) ->
+        (* We have membership recorded locally — always serve it, even if the
+           GitHub refresh failed. *)
+        Abb.Future.return (Ok installations)
+    | Ok [] -> (
+        (* Nothing recorded locally. Only report "no installations" when GitHub
+           confirmed it; otherwise we genuinely don't know yet (GitHub unreachable,
+           or the installation webhook hasn't landed) — surface that as
+           unavailable so the UI retries instead of showing demo mode. *)
+        match github_count with
+        | Some 0 -> Abb.Future.return (Ok [])
+        | Some _ | None -> Abb.Future.return (Error `Unavailable))
+    | Error _ as err -> Abb.Future.return err
 
   let get config storage =
     Brtl_ep.run_result_json ~f:(fun ctx ->
@@ -166,7 +210,7 @@ module Installations = struct
         Terrat_session.with_session ctx
         >>= fun user ->
         let open Abb.Future.Infix_monad in
-        get' config storage user
+        get' (Brtl_ctx.token ctx) config storage user
         >>= function
         | Ok installations ->
             let body =
@@ -174,20 +218,14 @@ module Installations = struct
                 { installations } |> to_yojson |> Yojson.Safe.to_string)
             in
             Abb.Future.return (Ok (Brtl_ctx.set_response (Brtl_rspnc.create ~status:`OK body) ctx))
-        | Error (`Refresh_err _ as err) ->
-            Logs.err (fun m ->
+        | Error `Unavailable ->
+            Logs.info (fun m ->
                 m
-                  "%s : GET : INSTALLATIONS : %a"
-                  (Brtl_ctx.token ctx)
-                  Terrat_vcs_service_github_user.pp_err
-                  err);
+                  "%s : GET : INSTALLATIONS : UNAVAILABLE : no local membership and GitHub \
+                   unreachable"
+                  (Brtl_ctx.token ctx));
             Abb.Future.return
-              (Ok (Brtl_ctx.set_response (Brtl_rspnc.create ~status:`Forbidden "") ctx))
-        | Error `Bad_refresh_token ->
-            Logs.err (fun m ->
-                m "%s : GET : INSTALLATIONS : BAD_REFRESH_TOKEN" (Brtl_ctx.token ctx));
-            Abb.Future.return
-              (Ok (Brtl_ctx.set_response (Brtl_rspnc.create ~status:`Forbidden "") ctx))
+              (Ok (Brtl_ctx.set_response (Brtl_rspnc.create ~status:`Service_unavailable "") ctx))
         | Error (#Pgsql_pool.err as err) ->
             Logs.err (fun m ->
                 m "%s : GET : INSTALLATIONS : %a" (Brtl_ctx.token ctx) Pgsql_pool.pp_err err);
@@ -196,24 +234,6 @@ module Installations = struct
         | Error (#Pgsql_io.err as err) ->
             Logs.err (fun m ->
                 m "%s : GET : INSTALLATIONS : %a" (Brtl_ctx.token ctx) Pgsql_io.pp_err err);
-            Abb.Future.return
-              (Ok (Brtl_ctx.set_response (Brtl_rspnc.create ~status:`Internal_server_error "") ctx))
-        | Error (#Terrat_github.get_user_installations_err as err) ->
-            Logs.err (fun m ->
-                m
-                  "%s : GET : INSTALLATIONS : %a"
-                  (Brtl_ctx.token ctx)
-                  Terrat_github.pp_get_user_installations_err
-                  err);
-            Abb.Future.return
-              (Ok (Brtl_ctx.set_response (Brtl_rspnc.create ~status:`Internal_server_error "") ctx))
-        | Error (#Terrat_vcs_service_github_user.err as err) ->
-            Logs.err (fun m ->
-                m
-                  "%s : GET : INSTALLATIONS : %a"
-                  (Brtl_ctx.token ctx)
-                  Terrat_vcs_service_github_user.pp_err
-                  err);
             Abb.Future.return
               (Ok (Brtl_ctx.set_response (Brtl_rspnc.create ~status:`Internal_server_error "") ctx)))
 end


### PR DESCRIPTION
## Description

Fixes #1314.

Users repeatedly reported logging in and seeing **demo mode** even though the Terrateam GitHub App was installed. "Demo mode" isn't a real mode — it's the fallback the UI shows whenever it computes that the user has zero installations, so anything that made the installations list come back empty (for any reason) presented as demo mode.

### Root cause

The installations list was recomputed on **every request** from a live GitHub call (`List_installations_for_authenticated_user`), intersected with the local DB, and returned as `200` even when empty — so the check was only as reliable as a live third-party round-trip plus a token refresh, and it **failed closed to empty**:

- `upsert_user_installations.sql` **deleted all of a user's memberships** whenever the resolved set came back empty (transient GitHub error, token-refresh race, eventual consistency, or the brand-new-install webhook race). `github_user_installations2` backs every user-scoped read (repos, runs, PRs, dirspaces), so wiping it emptied everything — not just the installation list.
- The frontend treated **any** load error as "zero installations," with no retry and no fallback, so a single blip stuck the user in demo mode for the whole session.

### Changes

Make installation detection resilient on both ends, following the existing repositories "serve-from-DB, refresh-from-GitHub" pattern.

**Backend** (`terrat_vcs_service_github_ep_user.ml`, SQL)
- Serve the list **authoritatively from the local DB** by `user_id` (`select_installations_for_user.sql`) — the read path no longer depends on GitHub being reachable.
- The live GitHub call becomes a **best-effort refresh**: on any token/GitHub/DB error it logs and serves the cached DB list.
- `upsert_user_installations.sql` is now **additive-only** — the destructive delete is gone, so a transient/empty/racy response can never erase memberships.
- Three states are now distinguished so we never mislabel "couldn't determine" as "empty": known membership → `200` (even if GitHub is down); GitHub confirms none → `200 []`; nothing recorded **and** GitHub unreachable → `503`, so the UI retries.

**Frontend** (`installations.ts`, `stores.ts`, `App.svelte`, `AuthenticationLoader.svelte`, …)
- Only a **successful** response is authoritative; errors never clear the list.
- Added a **last-known-good cache** (localStorage, hydrated on boot, cleared on logout) so a returning user is never dropped into demo mode by a transient failure.
- Error-with-no-cache now shows a **retry** screen instead of demo mode.

### Result

Returning users are served from the DB and stay in their workspace even during a GitHub outage. A genuinely new user with no installs still sees getting-started; a new user we can't yet resolve sees retry — never demo mode, and never a wrong org (membership is only ever what GitHub attributes to that user's token).

### Follow-ups (out of scope)

- Prune memberships when a user leaves an org (the additive-only upsert keeps them) — best handled by a periodic reconcile using the existing scheduler loop.
- `get_user_installations` still fetches only `per_page:100` with no pagination loop (now harmless since refresh never deletes).

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (explain):

## Checklist

- [ ] I have read the [contributing guidelines](https://github.com/terrateamio/terrateam/blob/main/CONTRIBUTING.md)
- [ ] The pull request title follows this format:
      `ISSUE_NUMBER ACTION_TYPE Short description` (e.g., `123 ADD Feature description`)
- [ ] I have added tests and documentation (if applicable)
- [ ] My changes generate no new warnings/errors and do not break existing functionality

## Additional context (optional)

<!-- Add any additional context here, e.g., screenshots, dependencies, etc. -->
