### PR TITLE
#1314 ADD Verbose logging to user GitHub installations endpoint

### DIFF
--- a/code/src/terrat_github/terrat_github.ml
+++ b/code/src/terrat_github/terrat_github.ml
@@ -68,6 +68,23 @@ type get_user_installations_err =
   ]
 [@@deriving show]
 
+type get_user_orgs_err =
+  [ Githubc2_abb.call_err
+  | `Unauthorized of Githubc2_components.Basic_error.t
+  | `Forbidden of Githubc2_components.Basic_error.t
+  | `Not_modified
+  ]
+[@@deriving show]
+
+type get_user_org_memberships_err =
+  [ Githubc2_abb.call_err
+  | `Unauthorized of Githubc2_components.Basic_error.t
+  | `Forbidden of Githubc2_components.Basic_error.t
+  | `Not_modified
+  | `Unprocessable_entity of Githubc2_components.Validation_error.t
+  ]
+[@@deriving show]
+
 type get_installation_repos_err =
   [ Githubc2_abb.call_err
   | `Not_modified
@@ -373,8 +390,34 @@ let get_user_installations client =
       make Parameters.(make ~per_page:100 ()))
   >>= fun resp ->
   match Openapi.Response.value resp with
-  | `OK R.OK.{ primary = Primary.{ installations; _ }; _ } -> Abb.Future.return (Ok installations)
+  | `OK R.OK.{ primary = Primary.{ installations; total_count; _ }; _ } ->
+      Abb.Future.return (Ok (installations, total_count))
   | (`Forbidden _ | `Not_modified | `Unauthorized _) as err -> Abb.Future.return (Error err)
+
+(* Diagnostic: the organizations the user's own token can see (gated by the app's org Members
+   permission and any org SSO/third-party approval). Used to localize empty /user/installations. *)
+let get_user_orgs client =
+  let open Abbs_future_combinators.Infix_result_monad in
+  Prmths.Counter.inc_one (Metrics.fn_call_total "get_user_orgs");
+  call client Githubc2_orgs.List_for_authenticated_user.(make Parameters.(make ~per_page:100 ()))
+  >>= fun resp ->
+  match Openapi.Response.value resp with
+  | `OK orgs -> Abb.Future.return (Ok orgs)
+  | (`Forbidden _ | `Not_modified | `Unauthorized _) as err -> Abb.Future.return (Error err)
+
+(* Diagnostic: the user's organization memberships (with role and active/pending state) as seen by
+   the user's token. Distinguishes "token cannot see the org at all" from "sees it but no install". *)
+let get_user_org_memberships client =
+  let open Abbs_future_combinators.Infix_result_monad in
+  Prmths.Counter.inc_one (Metrics.fn_call_total "get_user_org_memberships");
+  call
+    client
+    Githubc2_orgs.List_memberships_for_authenticated_user.(make Parameters.(make ~per_page:100 ()))
+  >>= fun resp ->
+  match Openapi.Response.value resp with
+  | `OK memberships -> Abb.Future.return (Ok memberships)
+  | (`Forbidden _ | `Not_modified | `Unauthorized _ | `Unprocessable_entity _) as err ->
+      Abb.Future.return (Error err)
 
 let get_installation_repos client =
   let module R = Githubc2_apps.List_repos_accessible_to_installation.Responses in

--- a/code/src/terrat_github/terrat_github.ml
+++ b/code/src/terrat_github/terrat_github.ml
@@ -169,6 +169,7 @@ type get_tree_err =
 type get_team_membership_in_org_err = Githubc2_abb.call_err [@@deriving show]
 type get_repo_collaborator_permission_err = Githubc2_abb.call_err [@@deriving show]
 type get_org_membership_err = Githubc2_abb.call_err [@@deriving show]
+type get_org_membership_diag_err = Githubc2_abb.call_err [@@deriving show]
 
 let max_get_tree_chunks = 20
 
@@ -719,6 +720,32 @@ let get_org_membership ~org ~user client =
       if state = `Active then
         Abb.Future.return (Ok (Some (if role = `Admin then `Admin else `User)))
       else Abb.Future.return (Ok None)
+
+(* Diagnostic: what the APP (installation token) sees about a user's membership in an org. Returns a
+   human-readable description rather than a decision, and distinguishes "not a member" from "the app
+   is not allowed to read org members" (which itself is a likely cause of empty user installations). *)
+let get_org_membership_diag ~org ~user client =
+  Prmths.Counter.inc_one (Metrics.fn_call_total "get_org_membership_diag");
+  let open Abbs_future_combinators.Infix_result_monad in
+  let module Membership = Githubc2_components.Org_membership in
+  call client Githubc2_orgs.Get_membership_for_user.(make Parameters.(make ~org ~username:user))
+  >>= fun resp ->
+  match Openapi.Response.value resp with
+  | `OK Membership.{ primary = Primary.{ role; state; _ }; _ } ->
+      let role =
+        match role with
+        | `Admin -> "admin"
+        | `Billing_manager -> "billing_manager"
+        | `Member -> "member"
+      in
+      let state =
+        match state with
+        | `Active -> "active"
+        | `Pending -> "pending"
+      in
+      Abb.Future.return (Ok (Printf.sprintf "member(role=%s,state=%s)" role state))
+  | `Not_found _ -> Abb.Future.return (Ok "not-a-member")
+  | `Forbidden _ -> Abb.Future.return (Ok "app-cannot-read-org-members(needs-org-Members:read)")
 
 module Commit_status = struct
   type create_err = Githubc2_abb.call_err [@@deriving show]

--- a/code/src/terrat_github/terrat_github.mli
+++ b/code/src/terrat_github/terrat_github.mli
@@ -125,6 +125,7 @@ type get_tree_err =
 type get_team_membership_in_org_err = Githubc2_abb.call_err [@@deriving show]
 type get_repo_collaborator_permission_err = Githubc2_abb.call_err [@@deriving show]
 type get_org_membership_err = Githubc2_abb.call_err [@@deriving show]
+type get_org_membership_diag_err = Githubc2_abb.call_err [@@deriving show]
 
 module Commit_status : sig
   type create_err = Githubc2_abb.call_err [@@deriving show]
@@ -357,6 +358,12 @@ val get_org_membership :
   user:string ->
   Githubc2_abb.t ->
   ([ `Admin | `User ] option, [> get_org_membership_err ]) result Abb.Future.t
+
+val get_org_membership_diag :
+  org:string ->
+  user:string ->
+  Githubc2_abb.t ->
+  (string, [> get_org_membership_diag_err ]) result Abb.Future.t
 
 (** GitHub does not include Oauth operations in their JSON schema, so implementing here. *)
 module Oauth : sig

--- a/code/src/terrat_github/terrat_github.mli
+++ b/code/src/terrat_github/terrat_github.mli
@@ -24,6 +24,23 @@ type get_user_installations_err =
   ]
 [@@deriving show]
 
+type get_user_orgs_err =
+  [ Githubc2_abb.call_err
+  | `Unauthorized of Githubc2_components.Basic_error.t
+  | `Forbidden of Githubc2_components.Basic_error.t
+  | `Not_modified
+  ]
+[@@deriving show]
+
+type get_user_org_memberships_err =
+  [ Githubc2_abb.call_err
+  | `Unauthorized of Githubc2_components.Basic_error.t
+  | `Forbidden of Githubc2_components.Basic_error.t
+  | `Not_modified
+  | `Unprocessable_entity of Githubc2_components.Validation_error.t
+  ]
+[@@deriving show]
+
 type get_installation_repos_err =
   [ Githubc2_abb.call_err
   | `Not_modified
@@ -250,7 +267,16 @@ val fetch_diff_files :
 
 val get_user_installations :
   Githubc2_abb.t ->
-  (Githubc2_components.Installation.t list, [> get_user_installations_err ]) result Abb.Future.t
+  (Githubc2_components.Installation.t list * int, [> get_user_installations_err ]) result
+  Abb.Future.t
+
+val get_user_orgs :
+  Githubc2_abb.t ->
+  (Githubc2_components.Organization_simple.t list, [> get_user_orgs_err ]) result Abb.Future.t
+
+val get_user_org_memberships :
+  Githubc2_abb.t ->
+  (Githubc2_components.Org_membership.t list, [> get_user_org_memberships_err ]) result Abb.Future.t
 
 val get_installation_repos :
   Githubc2_abb.t ->

--- a/code/src/terrat_vcs_service_github/sql/select_installations_for_diag.sql
+++ b/code/src/terrat_vcs_service_github/sql/select_installations_for_diag.sql
@@ -1,0 +1,1 @@
+select id, login from github_installations order by created_at desc limit 50

--- a/code/src/terrat_vcs_service_github/terrat_vcs_service_github_ep_user.ml
+++ b/code/src/terrat_vcs_service_github/terrat_vcs_service_github_ep_user.ml
@@ -121,8 +121,27 @@ module Installations = struct
         /% Var.(array (bigint "installation_ids")))
   end
 
-  let get' config storage user =
+  (* Render a GitHub installation as a compact, log-friendly summary. The installation [id] is the
+     value matched against the local github_installations table, so it is the key datum when
+     diagnosing why an installation that GitHub returns does not surface for a user. *)
+  let summarize_installation installation =
+    let module I = Githubc2_components.Installation in
+    let module Su = Githubc2_components.Simple_user in
+    let module En = Githubc2_components.Enterprise in
+    let { I.primary = { I.Primary.id; target_type; account; _ }; _ } = installation in
+    let login =
+      match account with
+      | Some (I.Primary.Account.Simple_user { Su.primary = { Su.Primary.login; _ }; _ }) -> login
+      | Some (I.Primary.Account.Enterprise { En.primary = { En.Primary.slug; _ }; _ }) -> slug
+      | None -> "<no-account>"
+    in
+    Printf.sprintf "id=%d type=%s login=%s" id target_type login
+
+  let get' ~request_id config storage user =
     let open Abbs_future_combinators.Infix_result_monad in
+    let module I = Githubc2_components.Installation in
+    let user_id = Terrat_user.id user in
+    Logs.info (fun m -> m "%s : INSTALLATIONS : user=%a : start" request_id Uuidm.pp user_id);
     Terrat_vcs_service_github_user.get_token config storage user
     >>= fun token ->
     Terrat_github.with_client
@@ -130,20 +149,41 @@ module Installations = struct
       (`Bearer token)
       Terrat_github.get_user_installations
     >>= fun installations ->
+    (* What GitHub reports for this user's token. GET /user/installations only returns installations
+       the user can reach through repositories they can access, so an org member with no access to a
+       covered repository legitimately sees an empty list here even though the app is installed. *)
+    Logs.info (fun m ->
+        m
+          "%s : INSTALLATIONS : user=%a : github_returned=%d : [%s]"
+          request_id
+          Uuidm.pp
+          user_id
+          (CCList.length installations)
+          (String.concat ", " (CCList.map summarize_installation installations)));
+    if CCList.is_empty installations then
+      Logs.warn (fun m ->
+          m
+            "%s : INSTALLATIONS : user=%a : github returned zero installations - the user's OAuth \
+             token cannot see any installation of this GitHub App. This is expected when the user \
+             cannot access (through their organization membership) any repository the app is \
+             installed on; verify the user has access to at least one covered repository and that \
+             SAML SSO is authorized for their token."
+            request_id
+            Uuidm.pp
+            user_id);
     Pgsql_pool.with_conn storage ~f:(fun db ->
-        let module I = Githubc2_components.Installation in
         Pgsql_io.Prepared_stmt.fetch
           db
           ~f:(fun _ _ _ -> ())
           (Sql.upsert_user_installations ())
-          (Terrat_user.id user)
+          user_id
           (CCList.map (fun { I.primary = { I.Primary.id; _ }; _ } -> Int64.of_int id) installations)
         >>= fun _ ->
         Pgsql_io.Prepared_stmt.fetch
           db
           (Sql.select_installations ())
           ~f:(fun id name account_status created_at trial_ends_at tier_name tier_features ->
-            let module I = Terrat_api_components.Installation in
+            let module Ai = Terrat_api_components.Installation in
             let module T = Terrat_api_components.Tier in
             let { Terrat_tier.num_users_per_month; _ } = tier_features in
             let tier =
@@ -157,8 +197,46 @@ module Installations = struct
                   };
               }
             in
-            { I.id = CCInt64.to_string id; name; account_status; created_at; trial_ends_at; tier })
-          (CCList.map (fun I.{ primary = Primary.{ id; _ }; _ } -> Int64.of_int id) installations))
+            { Ai.id = CCInt64.to_string id; name; account_status; created_at; trial_ends_at; tier })
+          (CCList.map (fun { I.primary = { I.Primary.id; _ }; _ } -> Int64.of_int id) installations))
+    >>= fun installations_result ->
+    let module Ai = Terrat_api_components.Installation in
+    (* What the user actually receives: GitHub's installations intersected with the local
+       github_installations table. If this is shorter than github_returned, the missing ids have no
+       installation row recorded locally. *)
+    Logs.info (fun m ->
+        m
+          "%s : INSTALLATIONS : user=%a : db_matched=%d : [%s]"
+          request_id
+          Uuidm.pp
+          user_id
+          (CCList.length installations_result)
+          (String.concat
+             ", "
+             (CCList.map
+                (fun { Ai.id; name; _ } -> Printf.sprintf "id=%s login=%s" id name)
+                installations_result)));
+    let matched_ids = CCList.map (fun { Ai.id; _ } -> id) installations_result in
+    let missing_from_db =
+      CCList.filter_map
+        (fun { I.primary = { I.Primary.id; _ }; _ } ->
+          let id = string_of_int id in
+          if CCList.mem ~eq:CCString.equal id matched_ids then None else Some id)
+        installations
+    in
+    if not (CCList.is_empty missing_from_db) then
+      Logs.warn (fun m ->
+          m
+            "%s : INSTALLATIONS : user=%a : missing_from_db=%d : ids=[%s] - these installations \
+             were returned by GitHub but have no row in the github_installations table, so they \
+             are dropped from the user's list (e.g. the install webhook was never received for \
+             this account)."
+            request_id
+            Uuidm.pp
+            user_id
+            (CCList.length missing_from_db)
+            (String.concat ", " missing_from_db));
+    Abb.Future.return (Ok installations_result)
 
   let get config storage =
     Brtl_ep.run_result_json ~f:(fun ctx ->
@@ -166,7 +244,7 @@ module Installations = struct
         Terrat_session.with_session ctx
         >>= fun user ->
         let open Abb.Future.Infix_monad in
-        get' config storage user
+        get' ~request_id:(Brtl_ctx.token ctx) config storage user
         >>= function
         | Ok installations ->
             let body =
@@ -177,32 +255,52 @@ module Installations = struct
         | Error (`Refresh_err _ as err) ->
             Logs.err (fun m ->
                 m
-                  "%s : GET : INSTALLATIONS : %a"
+                  "%s : GET : INSTALLATIONS : user=%a : %a"
                   (Brtl_ctx.token ctx)
+                  Uuidm.pp
+                  (Terrat_user.id user)
                   Terrat_vcs_service_github_user.pp_err
                   err);
             Abb.Future.return
               (Ok (Brtl_ctx.set_response (Brtl_rspnc.create ~status:`Forbidden "") ctx))
         | Error `Bad_refresh_token ->
             Logs.err (fun m ->
-                m "%s : GET : INSTALLATIONS : BAD_REFRESH_TOKEN" (Brtl_ctx.token ctx));
+                m
+                  "%s : GET : INSTALLATIONS : user=%a : BAD_REFRESH_TOKEN"
+                  (Brtl_ctx.token ctx)
+                  Uuidm.pp
+                  (Terrat_user.id user));
             Abb.Future.return
               (Ok (Brtl_ctx.set_response (Brtl_rspnc.create ~status:`Forbidden "") ctx))
         | Error (#Pgsql_pool.err as err) ->
             Logs.err (fun m ->
-                m "%s : GET : INSTALLATIONS : %a" (Brtl_ctx.token ctx) Pgsql_pool.pp_err err);
+                m
+                  "%s : GET : INSTALLATIONS : user=%a : %a"
+                  (Brtl_ctx.token ctx)
+                  Uuidm.pp
+                  (Terrat_user.id user)
+                  Pgsql_pool.pp_err
+                  err);
             Abb.Future.return
               (Ok (Brtl_ctx.set_response (Brtl_rspnc.create ~status:`Internal_server_error "") ctx))
         | Error (#Pgsql_io.err as err) ->
             Logs.err (fun m ->
-                m "%s : GET : INSTALLATIONS : %a" (Brtl_ctx.token ctx) Pgsql_io.pp_err err);
+                m
+                  "%s : GET : INSTALLATIONS : user=%a : %a"
+                  (Brtl_ctx.token ctx)
+                  Uuidm.pp
+                  (Terrat_user.id user)
+                  Pgsql_io.pp_err
+                  err);
             Abb.Future.return
               (Ok (Brtl_ctx.set_response (Brtl_rspnc.create ~status:`Internal_server_error "") ctx))
         | Error (#Terrat_github.get_user_installations_err as err) ->
             Logs.err (fun m ->
                 m
-                  "%s : GET : INSTALLATIONS : %a"
+                  "%s : GET : INSTALLATIONS : user=%a : %a"
                   (Brtl_ctx.token ctx)
+                  Uuidm.pp
+                  (Terrat_user.id user)
                   Terrat_github.pp_get_user_installations_err
                   err);
             Abb.Future.return
@@ -210,8 +308,10 @@ module Installations = struct
         | Error (#Terrat_vcs_service_github_user.err as err) ->
             Logs.err (fun m ->
                 m
-                  "%s : GET : INSTALLATIONS : %a"
+                  "%s : GET : INSTALLATIONS : user=%a : %a"
                   (Brtl_ctx.token ctx)
+                  Uuidm.pp
+                  (Terrat_user.id user)
                   Terrat_vcs_service_github_user.pp_err
                   err);
             Abb.Future.return

--- a/code/src/terrat_vcs_service_github/terrat_vcs_service_github_ep_user.ml
+++ b/code/src/terrat_vcs_service_github/terrat_vcs_service_github_ep_user.ml
@@ -137,6 +137,116 @@ module Installations = struct
     in
     Printf.sprintf "id=%d type=%s login=%s" id target_type login
 
+  (* Best-effort visibility probe. When GitHub returns no installations for a user's valid token we
+     ask that same token what else it can see - the authenticated identity, the orgs it can list,
+     and the user's org memberships (role + active/pending state). Comparing these against a working
+     user pinpoints where access is lost on GitHub's side. Every sub-call swallows its own errors
+     and only logs, so this never affects the response. *)
+  let log_github_visibility_diagnostics ~request_id ~user_id config token =
+    let vcs_config = Terrat_vcs_service_github_provider.Api.Config.vcs_config config in
+    let open Abb.Future.Infix_monad in
+    Terrat_github.user ~config:vcs_config ~access_token:token ()
+    >>= (fun res ->
+    (match res with
+    | Ok current_user ->
+        let module Gar = Githubc2_users.Get_authenticated.Responses.OK in
+        let module Pr = Githubc2_components.Private_user in
+        let module Pu = Githubc2_components.Public_user in
+        let login =
+          match current_user with
+          | Gar.Private_user { Pr.primary = { Pr.Primary.login; _ }; _ }
+          | Gar.Public_user { Pu.login; _ } -> login
+        in
+        Logs.info (fun m ->
+            m "%s : DIAG : user=%a : token_login=%s" request_id Uuidm.pp user_id login)
+    | Error err ->
+        Logs.warn (fun m ->
+            m
+              "%s : DIAG : user=%a : identity lookup failed : %a"
+              request_id
+              Uuidm.pp
+              user_id
+              Terrat_github.pp_user_err
+              err));
+    Abb.Future.return ())
+    >>= fun () ->
+    Terrat_github.with_client vcs_config (`Bearer token) Terrat_github.get_user_orgs
+    >>= (fun res ->
+    (match res with
+    | Ok orgs ->
+        let module O = Githubc2_components.Organization_simple in
+        Logs.info (fun m ->
+            m
+              "%s : DIAG : user=%a : user_orgs_visible=%d : [%s]"
+              request_id
+              Uuidm.pp
+              user_id
+              (CCList.length orgs)
+              (String.concat
+                 ", "
+                 (CCList.map (fun { O.primary = { O.Primary.login; _ }; _ } -> login) orgs)))
+    | Error err ->
+        Logs.warn (fun m ->
+            m
+              "%s : DIAG : user=%a : user_orgs lookup failed (a 403 here means the token cannot \
+               read this user's org list at all - app org Members:read permission or org \
+               SSO/third-party approval) : %a"
+              request_id
+              Uuidm.pp
+              user_id
+              Terrat_github.pp_get_user_orgs_err
+              err));
+    Abb.Future.return ())
+    >>= fun () ->
+    Terrat_github.with_client vcs_config (`Bearer token) Terrat_github.get_user_org_memberships
+    >>= fun res ->
+    (match res with
+    | Ok memberships ->
+        let module Om = Githubc2_components.Org_membership in
+        let module O = Githubc2_components.Organization_simple in
+        let show_membership
+            {
+              Om.primary =
+                {
+                  Om.Primary.organization = { O.primary = { O.Primary.login; _ }; _ };
+                  role;
+                  state;
+                  _;
+                };
+              _;
+            } =
+          let role =
+            match role with
+            | `Admin -> "admin"
+            | `Billing_manager -> "billing_manager"
+            | `Member -> "member"
+          in
+          let state =
+            match state with
+            | `Active -> "active"
+            | `Pending -> "pending"
+          in
+          Printf.sprintf "%s(role=%s,state=%s)" login role state
+        in
+        Logs.info (fun m ->
+            m
+              "%s : DIAG : user=%a : user_org_memberships=%d : [%s]"
+              request_id
+              Uuidm.pp
+              user_id
+              (CCList.length memberships)
+              (String.concat ", " (CCList.map show_membership memberships)))
+    | Error err ->
+        Logs.warn (fun m ->
+            m
+              "%s : DIAG : user=%a : org memberships lookup failed : %a"
+              request_id
+              Uuidm.pp
+              user_id
+              Terrat_github.pp_get_user_org_memberships_err
+              err));
+    Abb.Future.return (Ok ())
+
   let get' ~request_id config storage user =
     let open Abbs_future_combinators.Infix_result_monad in
     let module I = Githubc2_components.Installation in
@@ -148,29 +258,32 @@ module Installations = struct
       (Terrat_vcs_service_github_provider.Api.Config.vcs_config config)
       (`Bearer token)
       Terrat_github.get_user_installations
-    >>= fun installations ->
-    (* What GitHub reports for this user's token. GET /user/installations only returns installations
-       the user can reach through repositories they can access, so an org member with no access to a
-       covered repository legitimately sees an empty list here even though the app is installed. *)
+    >>= fun (installations, total_count) ->
+    (* github_returned is what the user actually gets; total_count is GitHub's own count of
+       installations it considers accessible to this token (if they disagree, GitHub is filtering
+       the page). GET /user/installations only surfaces installations the user can reach through a
+       repository they can access. *)
     Logs.info (fun m ->
         m
-          "%s : INSTALLATIONS : user=%a : github_returned=%d : [%s]"
+          "%s : INSTALLATIONS : user=%a : github_returned=%d : total_count=%d : [%s]"
           request_id
           Uuidm.pp
           user_id
           (CCList.length installations)
+          total_count
           (String.concat ", " (CCList.map summarize_installation installations)));
-    if CCList.is_empty installations then
-      Logs.warn (fun m ->
-          m
-            "%s : INSTALLATIONS : user=%a : github returned zero installations - the user's OAuth \
-             token cannot see any installation of this GitHub App. This is expected when the user \
-             cannot access (through their organization membership) any repository the app is \
-             installed on; verify the user has access to at least one covered repository and that \
-             SAML SSO is authorized for their token."
-            request_id
-            Uuidm.pp
-            user_id);
+    (if CCList.is_empty installations then (
+       Logs.warn (fun m ->
+           m
+             "%s : INSTALLATIONS : user=%a : github_returned=0 - GitHub returned an empty \
+              installation list for this user's valid token (this is the demo-mode trigger). \
+              Emitting visibility diagnostics below to localize where access is lost."
+             request_id
+             Uuidm.pp
+             user_id);
+       log_github_visibility_diagnostics ~request_id ~user_id config token)
+     else Abb.Future.return (Ok ()))
+    >>= fun () ->
     Pgsql_pool.with_conn storage ~f:(fun db ->
         Pgsql_io.Prepared_stmt.fetch
           db

--- a/code/src/terrat_vcs_service_github/terrat_vcs_service_github_ep_user.ml
+++ b/code/src/terrat_vcs_service_github/terrat_vcs_service_github_ep_user.ml
@@ -119,6 +119,17 @@ module Installations = struct
         /^ read [%blob "sql/upsert_user_installations.sql"]
         /% Var.(uuid "user_id")
         /% Var.(array (bigint "installation_ids")))
+
+    let select_installations_for_diag () =
+      Pgsql_io.Typed_sql.(
+        sql
+        //
+        (* id *)
+        Ret.bigint
+        //
+        (* login *)
+        Ret.text
+        /^ read [%blob "sql/select_installations_for_diag.sql"])
   end
 
   (* Render a GitHub installation as a compact, log-friendly summary. The installation [id] is the
@@ -137,17 +148,111 @@ module Installations = struct
     in
     Printf.sprintf "id=%d type=%s login=%s" id target_type login
 
+  (* App-side cross-check. For each org Terrateam has an installation for, ask the APP (installation
+     token) whether it considers [login] a member. If the app confirms an active membership in an org
+     whose installation the user's OWN token did not return, that is an airtight GitHub-side
+     regression to report. "app-cannot-read-org-members" instead means the app lacks the org
+     Members:read permission, which is itself a leading suspect for empty user installations. *)
+  let log_app_token_cross_check ~request_id ~user_id config storage ~login =
+    let vcs_config = Terrat_vcs_service_github_provider.Api.Config.vcs_config config in
+    let open Abb.Future.Infix_monad in
+    Pgsql_pool.with_conn storage ~f:(fun db ->
+        Pgsql_io.Prepared_stmt.fetch
+          db
+          (Sql.select_installations_for_diag ())
+          ~f:(fun id org_login -> (id, org_login)))
+    >>= function
+    | Error (#Pgsql_pool.err as err) ->
+        Logs.warn (fun m ->
+            m
+              "%s : DIAG : user=%a : cross-check could not read local installations : %a"
+              request_id
+              Uuidm.pp
+              user_id
+              Pgsql_pool.pp_err
+              err);
+        Abb.Future.return (Ok ())
+    | Error (#Pgsql_io.err as err) ->
+        Logs.warn (fun m ->
+            m
+              "%s : DIAG : user=%a : cross-check could not read local installations : %a"
+              request_id
+              Uuidm.pp
+              user_id
+              Pgsql_io.pp_err
+              err);
+        Abb.Future.return (Ok ())
+    | Ok installations ->
+        Logs.info (fun m ->
+            m
+              "%s : DIAG : user=%a : cross_check_login=%s : asking the app token about this user's \
+               membership in %d local installation(s)"
+              request_id
+              Uuidm.pp
+              user_id
+              login
+              (CCList.length installations));
+        Abbs_future_combinators.List_result.iter
+          ~f:(fun (installation_id, org_login) ->
+            Terrat_github.get_installation_access_token vcs_config (CCInt64.to_int installation_id)
+            >>= function
+            | Error err ->
+                Logs.warn (fun m ->
+                    m
+                      "%s : DIAG : user=%a : cross-check could not mint app token for org=%s \
+                       installation_id=%Ld : %a"
+                      request_id
+                      Uuidm.pp
+                      user_id
+                      org_login
+                      installation_id
+                      Terrat_github.pp_get_installation_access_token_err
+                      err);
+                Abb.Future.return (Ok ())
+            | Ok inst_token -> (
+                Terrat_github.with_client
+                  vcs_config
+                  (`Bearer inst_token)
+                  (Terrat_github.get_org_membership_diag ~org:org_login ~user:login)
+                >>= function
+                | Ok desc ->
+                    Logs.info (fun m ->
+                        m
+                          "%s : DIAG : user=%a : app_sees org=%s installation_id=%Ld : %s"
+                          request_id
+                          Uuidm.pp
+                          user_id
+                          org_login
+                          installation_id
+                          desc);
+                    Abb.Future.return (Ok ())
+                | Error err ->
+                    Logs.warn (fun m ->
+                        m
+                          "%s : DIAG : user=%a : app membership check failed org=%s \
+                           installation_id=%Ld : %a"
+                          request_id
+                          Uuidm.pp
+                          user_id
+                          org_login
+                          installation_id
+                          Terrat_github.pp_get_org_membership_diag_err
+                          err);
+                    Abb.Future.return (Ok ())))
+          installations
+        >>= fun _ -> Abb.Future.return (Ok ())
+
   (* Best-effort visibility probe. When GitHub returns no installations for a user's valid token we
      ask that same token what else it can see - the authenticated identity, the orgs it can list,
      and the user's org memberships (role + active/pending state). Comparing these against a working
      user pinpoints where access is lost on GitHub's side. Every sub-call swallows its own errors
      and only logs, so this never affects the response. *)
-  let log_github_visibility_diagnostics ~request_id ~user_id config token =
+  let log_github_visibility_diagnostics ~request_id ~user_id config storage token =
     let vcs_config = Terrat_vcs_service_github_provider.Api.Config.vcs_config config in
     let open Abb.Future.Infix_monad in
     Terrat_github.user ~config:vcs_config ~access_token:token ()
     >>= (fun res ->
-    (match res with
+    match res with
     | Ok current_user ->
         let module Gar = Githubc2_users.Get_authenticated.Responses.OK in
         let module Pr = Githubc2_components.Private_user in
@@ -158,7 +263,8 @@ module Installations = struct
           | Gar.Public_user { Pu.login; _ } -> login
         in
         Logs.info (fun m ->
-            m "%s : DIAG : user=%a : token_login=%s" request_id Uuidm.pp user_id login)
+            m "%s : DIAG : user=%a : token_login=%s" request_id Uuidm.pp user_id login);
+        Abb.Future.return (Some login)
     | Error err ->
         Logs.warn (fun m ->
             m
@@ -167,9 +273,9 @@ module Installations = struct
               Uuidm.pp
               user_id
               Terrat_github.pp_user_err
-              err));
-    Abb.Future.return ())
-    >>= fun () ->
+              err);
+        Abb.Future.return None)
+    >>= fun login_opt ->
     Terrat_github.with_client vcs_config (`Bearer token) Terrat_github.get_user_orgs
     >>= (fun res ->
     (match res with
@@ -245,7 +351,9 @@ module Installations = struct
               user_id
               Terrat_github.pp_get_user_org_memberships_err
               err));
-    Abb.Future.return (Ok ())
+    match login_opt with
+    | None -> Abb.Future.return (Ok ())
+    | Some login -> log_app_token_cross_check ~request_id ~user_id config storage ~login
 
   let get' ~request_id config storage user =
     let open Abbs_future_combinators.Infix_result_monad in
@@ -281,7 +389,7 @@ module Installations = struct
              request_id
              Uuidm.pp
              user_id);
-       log_github_visibility_diagnostics ~request_id ~user_id config token)
+       log_github_visibility_diagnostics ~request_id ~user_id config storage token)
      else Abb.Future.return (Ok ()))
     >>= fun () ->
     Pgsql_pool.with_conn storage ~f:(fun db ->


### PR DESCRIPTION
Logs, per request, what GET /user/installations returns from GitHub (count plus each installation's id/type/login) versus what survives the intersection with the local github_installations table (db_matched). Warns when GitHub returns zero installations for the user's token and when ids are dropped because no local install row exists. Error branches now carry the user id.

## Description

<!-- Briefly describe the changes and the issue it fixes. -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (explain):

## Checklist

- [ ] I have read the [contributing guidelines](https://github.com/terrateamio/terrateam/blob/main/CONTRIBUTING.md)
- [ ] The pull request title follows this format:
      `ISSUE_NUMBER ACTION_TYPE Short description` (e.g., `123 ADD Feature description`)
- [ ] I have added tests and documentation (if applicable)
- [ ] My changes generate no new warnings/errors and do not break existing functionality

## Additional context (optional)

<!-- Add any additional context here, e.g., screenshots, dependencies, etc. -->
