### PR TITLE
1214 ADD Show workspace summary above collapsible plan output

### DIFF
--- a/code/src/terrat_vcs_github_comment_templates/tmpl/plan_complete2.tmpl
+++ b/code/src/terrat_vcs_github_comment_templates/tmpl/plan_complete2.tmpl
@@ -95,8 +95,15 @@ A gate is satisfied only when all conditions are met. See [documentation](https:
   {%- endif %}
 
 ## Terrateam Plan Output{% if environment is defined %}: {{ environment }}{% endif %} :thumbsup:
+
+| Dir | Workspace | Status |
+|-----|-----------|--------|
+{%- for d in dirspaces %}
+| `{{ d.dir }}` | `{{ d.workspace }}` | {% if d.success %}{% if d.has_changes is defined and d.has_changes %}⚠️ Changes{% elif d.has_changes is defined and not d.has_changes %}✅ No changes{% else %}✅{% endif %}{% else %}❌ Failed{% endif %} |
+{%- endfor %}
+
 <details>
-  <summary>Expand for plan output details</summary>
+  <summary>Expand for full plan output</summary>
 
 {%- else %}
 ## Plans :heavy_multiplication_x:
@@ -115,8 +122,15 @@ Running plans **FAILED**.  See **Terrateam Plan Output**.
 After resolving the issue, run `terrateam plan` to execute the plan operation again.
 
 ## Terrateam Plan Output{% if environment is defined %}: {{ environment }}{% endif %} :heavy_multiplication_x:
+
+| Dir | Workspace | Status |
+|-----|-----------|--------|
+{%- for d in dirspaces %}
+| `{{ d.dir }}` | `{{ d.workspace }}` | {% if d.success %}{% if d.has_changes is defined and d.has_changes %}⚠️ Changes{% elif d.has_changes is defined and not d.has_changes %}✅ No changes{% else %}✅{% endif %}{% else %}❌ Failed{% endif %} |
+{%- endfor %}
+
 <details>
-  <summary>Expand for plan output details</summary>
+  <summary>Expand for full plan output</summary>
 
 {%- endif %}
 {%- if pre_hooks %}

--- a/code/src/terrat_vcs_gitlab_comment_templates/tmpl/plan_complete2.tmpl
+++ b/code/src/terrat_vcs_gitlab_comment_templates/tmpl/plan_complete2.tmpl
@@ -95,13 +95,20 @@ A gate is satisfied only when all conditions are met. See [documentation](https:
   {%- endif %}
 
 ## Terrateam Plan Output{% if environment is defined %}: {{ environment }}{% endif %} :thumbsup:
+
+| Dir | Workspace | Status |
+|-----|-----------|--------|
+{%- for d in dirspaces %}
+| `{{ d.dir }}` | `{{ d.workspace }}` | {% if d.success %}{% if d.has_changes is defined and d.has_changes %}⚠️ Changes{% elif d.has_changes is defined and not d.has_changes %}✅ No changes{% else %}✅{% endif %}{% else %}❌ Failed{% endif %} |
+{%- endfor %}
+
 <details>
-  <summary>Expand for plan output details</summary>
+  <summary>Expand for full plan output</summary>
 
 {%- else %}
 ## Plans :heavy_multiplication_x:
   {%- if work_manifest_url is defined %}
- 
+
 Outputs can be viewed in the Terrateam Console [here]({{ work_manifest_url }}).
 
   {%- endif %}
@@ -115,8 +122,15 @@ Running plans **FAILED**.  See **Terrateam Plan Output**.
 After resolving the issue, run `terrateam plan` to execute the plan operation again.
 
 ## Terrateam Plan Output{% if environment is defined %}: {{ environment }}{% endif %} :heavy_multiplication_x:
+
+| Dir | Workspace | Status |
+|-----|-----------|--------|
+{%- for d in dirspaces %}
+| `{{ d.dir }}` | `{{ d.workspace }}` | {% if d.success %}{% if d.has_changes is defined and d.has_changes %}⚠️ Changes{% elif d.has_changes is defined and not d.has_changes %}✅ No changes{% else %}✅{% endif %}{% else %}❌ Failed{% endif %} |
+{%- endfor %}
+
 <details>
-  <summary>Expand for plan output details</summary>
+  <summary>Expand for full plan output</summary>
 
 {%- endif %}
 {%- if pre_hooks %}


### PR DESCRIPTION
## Problem

When a PR touches multiple directories/workspaces, the Terrateam plan comment wraps all output — including the per-workspace headers — inside a `<details>` block. Reviewers must expand it just to see which workspaces ran and whether they have changes.

This is related to #1214.

## Change

Add a summary table **above** the `<details>` block in both the GitHub and GitLab `plan_complete2.tmpl` templates. The table shows dir, workspace, and status (⚠️ Changes / ✅ No changes / ❌ Failed) at a glance without any clicks.

**Before:**
```
## Terrateam Plan Output :thumbsup:
<details>
  <summary>Expand for plan output details</summary>
  ## fol/another-sample/terraform | app_prod | Success ...
  ...
```

**After:**
```
## Terrateam Plan Output :thumbsup:

| Dir | Workspace | Status |
|-----|-----------|--------|
| `fol/another-sample/terraform` | `app_dev3` | ⚠️ Changes |
| `sample-component/terraform` | `app_prod` | ✅ No changes |

<details>
  <summary>Expand for full plan output</summary>
  ...
```

## Files changed

- `code/src/terrat_vcs_github_comment_templates/tmpl/plan_complete2.tmpl`
- `code/src/terrat_vcs_gitlab_comment_templates/tmpl/plan_complete2.tmpl`

Both success and failure paths updated.