### PR TITLE
1331 ADD Show plan summary above expand details in GitHub comments

### DIFF
--- a/code/src/terrat_vcs_github_comment/terrat_vcs_github_comment_publishers.ml
+++ b/code/src/terrat_vcs_github_comment/terrat_vcs_github_comment_publishers.ml
@@ -266,6 +266,31 @@ let output_of_steps steps =
 
 let kv_of_outputs outputs = CCList.map Output.to_kv outputs
 
+let plan_summary_of_steps steps =
+  let module P = struct
+    type t = {
+      text : string;
+      plan : string option; [@default None]
+    }
+    [@@deriving of_yojson { strict = false }]
+  end in
+  let module O = Terrat_api_components.Workflow_step_output in
+  CCList.find_map
+    (function
+      | { O.step = "tf/plan" | "pulumi/plan" | "custom/plan" | "fly/plan";
+          payload;
+          success = true;
+          _ } -> (
+          match P.of_yojson (O.Payload.to_yojson payload) with
+          | Ok { P.text; plan } ->
+              let content = CCOption.get_or ~default:text plan in
+              content
+              |> CCString.split_on_char '\n'
+              |> CCList.find_opt (CCString.prefix ~pre:"Plan:")
+          | Error _ -> None)
+      | _ -> None)
+    steps
+
 let dirspace_compare (dirspace1, steps1) (dirspace2, steps2) =
   let module Cmp = struct
     type t = bool * bool * Terrat_dirspace.t [@@deriving ord]
@@ -440,6 +465,7 @@ module Publisher_tools = struct
                       (fun ({ Terrat_dirspace.dir; workspace }, steps) ->
                         let has_changes = steps_has_changes steps in
                         let success = steps_success steps in
+                        let plan_summary = plan_summary_of_steps steps in
                         `Assoc
                           (CCList.flatten
                              [
@@ -453,6 +479,10 @@ module Publisher_tools = struct
                                         (Output.filter ~overall_success (output_of_steps steps))) );
                                  ("has_changes", `Bool has_changes);
                                ];
+                               CCOption.map_or
+                                 ~default:[]
+                                 (fun s -> [ ("plan_summary", `String s) ])
+                                 plan_summary;
                              ]))
                       dirspaces) );
                ( "gates",

--- a/code/src/terrat_vcs_github_comment_templates/tmpl/plan_complete2.tmpl
+++ b/code/src/terrat_vcs_github_comment_templates/tmpl/plan_complete2.tmpl
@@ -95,6 +95,16 @@ A gate is satisfied only when all conditions are met. See [documentation](https:
   {%- endif %}
 
 ## Terrateam Plan Output{% if environment is defined %}: {{ environment }}{% endif %} :thumbsup:
+
+{%- set summaries = dirspaces | selectattr("plan_summary") | list %}
+{%- if summaries %}
+| Dir | Workspace | Changes |
+| --- | --------- | ------- |
+  {%- for d in summaries %}
+| `{{ d.dir }}` | `{{ d.workspace }}` | {{ d.plan_summary }} |
+  {%- endfor %}
+
+{%- endif %}
 <details>
   <summary>Expand for plan output details</summary>
 


### PR DESCRIPTION
## Description

Fixes #1331. When Terraform generates a plan with changes, the `Plan: N to add, N to change, N to destroy.` summary line is currently buried inside the collapsible details block — reviewers must expand it to spot destructive changes.

This PR surfaces that line in a table **above** the `<details>` block so it's immediately visible on every plan comment:

| Dir | Workspace | Changes |
| --- | --------- | ------- |
| `terraform/app` | `default` | Plan: 2 to add, 1 to change, 1 to destroy. |

**Changes:**

- `terrat_vcs_github_comment_publishers.ml` — new `plan_summary_of_steps` function scans the plan step payload for a line beginning with `Plan:` (covers `tf/plan`, `pulumi/plan`, `custom/plan`, `fly/plan`). Result is attached as an optional `plan_summary` field on each dirspace in the template data.
- `plan_complete2.tmpl` — renders a summary table between the `## Terrateam Plan Output` heading and the `<details>` block whenever one or more dirspaces have a plan summary. The table is omitted entirely when no summaries are present (e.g. no-change plans).

## Type of change

- [x] New feature

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/terrateamio/terrateam/blob/main/CONTRIBUTING.md)
- [x] The pull request title follows this format: `ISSUE_NUMBER ACTION_TYPE Short description`
- [x] My changes generate no new warnings/errors and do not break existing functionality