### PR TITLE
#1343 FIX Make pgsql_io fail fast on error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,9 @@ pnpm-debug.log*
 # Temporary files
 *~
 
+# Test TAP output
+*.tap
+
 # Python cache
 *__pycache__.*
 

--- a/code/src/pgsql_io/pgsql_io.ml
+++ b/code/src/pgsql_io/pgsql_io.ml
@@ -44,6 +44,15 @@ let gen_unique_id t prefix =
   t.unique_id <- t.unique_id + 1;
   ret
 
+(* Defined up here (rather than near the other lifecycle functions) so the Io
+   module can call it directly when it needs to fail a connection. *)
+let destroy t =
+  (* Destroy is idempotent *)
+  if t.connected then (
+    t.connected <- false;
+    Abbs_future_combinators.ignore (Abbs_io_buffered.close_writer t.w))
+  else Abb.Future.return ()
+
 type integrity_err = {
   code : string;
   message : string;
@@ -171,16 +180,64 @@ module Io = struct
          * List.iter (fun frame -> Printf.printf "Fs %s\n%!" (Pgsql_codec.Frame.Backend.show frame)) fs; *)
         Abb.Future.return (Ok fs)
 
-  let error_response conn fs =
+  (* The backend's ReadyForQuery status byte ('I' idle, 'T' in tx, 'E' failed
+     tx) is the authoritative transaction state.  Trust it over our own in_tx
+     flag.  Gating the drain on in_tx (rather than resyncing from the server)
+     means a stale in_tx makes us reject the real ReadyForQuery and wait forever
+     for one that will never come -- a permanent idle-in-transaction hang.  Loud
+     log on disagreement so the desync is visible in production. *)
+  let resync_in_tx conn status =
+    let backend_in_tx = status = 'T' || status = 'E' in
+    if backend_in_tx <> conn.in_tx then (
+      (* The connection was in an unexpected state: our in_tx flag disagreed with
+         the backend's authoritative transaction status.  Resync the flag so this
+         op fails fast (instead of hanging on a ReadyForQuery that never comes),
+         but also FAIL THE CONNECTION -- a desync means we can no longer trust the
+         frame stream, so mark it dead.  The pool destroys dead connections on
+         return rather than handing the corruption to the next caller. *)
+      Logs.err (fun m ->
+          m
+            "%s CONNECTION DESYNC DETECTED : in_tx=%b backend_status=%c : failing and closing the \
+             connection"
+            (Uuidm.to_string conn.id)
+            conn.in_tx
+            status);
+      conn.in_tx <- backend_in_tx;
+      (* Fail the connection: a desync means we can no longer trust the frame
+         stream.  [destroy] flips [connected] AND closes the writer, so the
+         underlying socket is released (not leaked) and the connection is never
+         reused.  Idempotent, so a later [destroy] from the pool is a safe
+         no-op. *)
+      destroy conn)
+    else (
+      conn.in_tx <- backend_in_tx;
+      Abb.Future.return ())
+
+  (* Drain frames up to the next ReadyForQuery -- [consume] runs the actual
+     consume loop with the status-capturing predicate we pass it -- then resync
+     conn.in_tx from the backend's authoritative status.  Shared by
+     [error_response] and [reset] so the ReadyForQuery / in_tx handling lives in
+     exactly one place. *)
+  let drain_to_ready_for_query conn ~consume =
     let open Abbs_future_combinators.Infix_result_monad in
     conn.expected_frames <- [];
-    consume_until ~fs conn (function
-      | Pgsql_codec.Frame.Backend.ReadyForQuery { status = 'T' | 'E' } when conn.in_tx -> true
-      | Pgsql_codec.Frame.Backend.ReadyForQuery { status = 'I' } when not conn.in_tx -> true
+    let status = ref None in
+    consume (function
+      | Pgsql_codec.Frame.Backend.ReadyForQuery { status = s } ->
+          status := Some s;
+          true
       | _ -> false)
     >>= fun res ->
+    let open Abb.Future.Infix_monad in
+    (match !status with
+      | Some s -> resync_in_tx conn s
+      | None -> Abb.Future.return ())
+    >>= fun () ->
     assert (res = []);
     Abb.Future.return (Ok ())
+
+  let error_response conn fs =
+    drain_to_ready_for_query conn ~consume:(fun is_ready -> consume_until ~fs conn is_ready)
 
   let handle_err_frame msgs =
     let c = CCList.Assoc.get_exn ~eq:Char.equal 'C' msgs in
@@ -246,20 +303,8 @@ module Io = struct
     let open Abbs_future_combinators.Infix_result_monad in
     send_frame conn Pgsql_codec.Frame.Frontend.Sync
     >>= fun () ->
-    conn.expected_frames <- [];
-    consume_matching
-      ~skip_leading_unmatched:true
-      conn
-      Pgsql_codec.Frame.Backend.
-        [
-          (function
-          | ReadyForQuery { status = 'T' | 'E' } when conn.in_tx -> true
-          | ReadyForQuery { status = 'I' } when not conn.in_tx -> true
-          | _ -> false);
-        ]
-    >>= fun res ->
-    assert (res = []);
-    Abb.Future.return (Ok ())
+    drain_to_ready_for_query conn ~consume:(fun is_ready ->
+        consume_matching ~skip_leading_unmatched:true conn [ is_ready ])
 end
 
 type frame_err =
@@ -1458,13 +1503,6 @@ let create
     | Error `Unsupported_auth_sspi_err
     | Error (`Unexpected _)
     | Error (`Parse_error _) ) as err -> Abb.Future.return err
-
-let destroy t =
-  (* Destroy is idempotent *)
-  if t.connected then (
-    t.connected <- false;
-    Abbs_future_combinators.ignore (Abbs_io_buffered.close_writer t.w))
-  else Abb.Future.return ()
 
 let connected t = t.connected
 let id t = t.id

--- a/code/src/pgsql_test_client/pgsql_test_client.ml
+++ b/code/src/pgsql_test_client/pgsql_test_client.ml
@@ -21,7 +21,7 @@ let with_conn :
     ('a, 'e) result Abb.Future.t =
  fun f ->
   let open Abb.Future.Infix_monad in
-  Pgsql_io.create ~tls_config:(`Require tls_config) ~host ~user ~passwd database
+  Pgsql_io.create ~tls_config:(`Prefer tls_config) ~host ~user ~passwd database
   >>= function
   | Ok conn ->
       Abbs_future_combinators.with_finally
@@ -1907,11 +1907,322 @@ let test_ret_b_all_types =
       ignore (Oth.Assert.ok ~pp:pp_pgsql_combined_err r);
       Abb.Future.return ())
 
+let test_large_jsonb_fetch =
+  Oth_abb.test
+    ~desc:"Large jsonb fetch (simulate compute_node_work.work read-back)"
+    ~name:"large_jsonb_fetch"
+    (fun () ->
+      let open Abb.Future.Infix_monad in
+      (* Faithfully mirror compute_node_work: same column shape, read back the
+         row's OWN uncommitted write inside a transaction, via the exact 4-column
+         Ret shape used by select_compute_node_work, with realistic config-like
+         jsonb content (unicode / special chars / nested structure), not a flat
+         ASCII blob. *)
+      let uuid s =
+        match Uuidm.of_string s with
+        | Some u -> u
+        | None -> failwith "bad uuid"
+      in
+      let mk_payload filler_size =
+        `Assoc
+          [
+            ("version", `Int 1);
+            ( "config",
+              `Assoc
+                [
+                  ( "workflows",
+                    `List
+                      [
+                        `Assoc
+                          [
+                            ("tag_query", `String "dir:services/* and (env:prod or env:dev)");
+                            ("engine", `String "terraform");
+                          ];
+                      ] );
+                  ( "dirs",
+                    `Assoc
+                      [
+                        ( "services/caf\xc3\xa9-app",
+                          `Assoc
+                            [
+                              ( "tags",
+                                `List
+                                  [
+                                    `String "na\xc3\xafve";
+                                    `String "\xe6\x97\xa5\xe6\x9c\xac\xe8\xaa\x9e";
+                                  ] );
+                            ] );
+                      ] );
+                  ( "notes",
+                    `String
+                      "sp\xc3\xabcial \xe2\x80\x94 chars: \"quotes\", \\backslash, \ttab, emoji \
+                       \xf0\x9f\x9a\x80" );
+                ] );
+            ( "dirspaces",
+              `List
+                (List.init 50 (fun i ->
+                     `Assoc
+                       [
+                         ("dir", `String (Printf.sprintf "services/svc-%d" i));
+                         ("workspace", `String "default");
+                       ])) );
+            ("filler", `String (String.make filler_size 'x'));
+          ]
+      in
+      let f conn =
+        let create_sql =
+          Pgsql_io.Typed_sql.(
+            sql
+            /^ "CREATE TABLE foo (compute_node uuid, created_at timestamptz default now(), state \
+                text, work jsonb not null, work_manifest uuid)")
+        in
+        let upsert_sql =
+          Pgsql_io.Typed_sql.(
+            sql
+            /^ "INSERT INTO foo (compute_node, state, work, work_manifest) VALUES($cn, 'created', \
+                $work, $wm)"
+            /% Var.uuid "cn"
+            /% Var.json "work"
+            /% Var.uuid "wm")
+        in
+        (* Exact shape of select_compute_node_work. *)
+        let select_sql =
+          Pgsql_io.Typed_sql.(
+            sql
+            // Ret.text
+            // Ret.text
+            // Ret.json
+            // Ret.uuid
+            /^ "SELECT to_char(created_at, 'YYYY-MM-DD\"T\"HH24:MI:SS\"Z\"'), state, work, \
+                work_manifest FROM foo WHERE compute_node = $cn"
+            /% Var.uuid "cn")
+        in
+        Pgsql_io.Prepared_stmt.execute conn create_sql
+        >>= function
+        | Error err ->
+            Logs.err (fun m -> m "CREATE_ERR : %s" (Pgsql_io.show_err err));
+            Abb.Future.return (Ok ())
+        | Ok () ->
+            let cn = uuid "43df20b3-eb5e-4c00-b1ef-f094d6641087" in
+            let wm = uuid "43df20b3-eb5e-4c00-b1ef-f094d6641087" in
+            let sizes = [ 0; 4096; 65536; 1048576; 16777216 ] in
+            let rec sweep idx = function
+              | [] ->
+                  Logs.info (fun m -> m "SWEEP_DONE : no hang reproduced");
+                  Abb.Future.return (Ok ())
+              | filler :: rest -> (
+                  Logs.info (fun m -> m "ITER_START : idx=%d : filler=%d bytes" idx filler);
+                  (* upsert + read-back-own-uncommitted-write inside one tx,
+                     exactly like set_work + the second query_work. *)
+                  Abbs_future_combinators.timeout
+                    ~timeout:(Abb.Sys.sleep 25.0)
+                    (Pgsql_io.tx conn ~f:(fun () ->
+                         let open Abbs_future_combinators.Infix_result_monad in
+                         Pgsql_io.Prepared_stmt.execute conn upsert_sql cn (mk_payload filler) wm
+                         >>= fun () ->
+                         Logs.info (fun m -> m "READBACK_START : idx=%d : filler=%d" idx filler);
+                         Pgsql_io.Prepared_stmt.fetch
+                           conn
+                           select_sql
+                           ~f:(fun _created state _work wm -> (state, wm))
+                           cn
+                         >>= fun rows -> Abb.Future.return (Ok (List.length rows))))
+                  >>= function
+                  | `Ok (Ok n) ->
+                      Logs.info (fun m ->
+                          m "READBACK_OK : idx=%d : filler=%d : rows=%d" idx filler n);
+                      sweep (idx + 1) rest
+                  | `Ok (Error err) ->
+                      Logs.err (fun m ->
+                          m
+                            "READBACK_ERR : idx=%d : filler=%d : %s"
+                            idx
+                            filler
+                            (Pgsql_io.show_err err));
+                      Abb.Future.return (Ok ())
+                  | `Timeout ->
+                      Logs.err (fun m ->
+                          m
+                            "READBACK_HANG : idx=%d : filler=%d : *** 25s+ STALL REPRODUCED ***"
+                            idx
+                            filler);
+                      Abb.Future.return (Ok ()))
+            in
+            sweep 0 sizes
+      in
+      with_conn f
+      >>= fun r ->
+      ignore (Oth.Assert.ok ~pp:pp_pgsql_combined_err r);
+      Abb.Future.return ())
+
+(* The user's scenario: issue a query that errors, do NOT bubble the error up
+   the result monad -- just ignore it -- then issue another query on the SAME
+   connection and see whether it hangs.  Run across the meaningful variants:
+   outside vs inside a tx, and a runtime error (1/0, fails at Execute, after
+   Sync) vs a parse-time error (missing relation, fails at Parse). *)
+let test_ignore_error_then_query =
+  Oth_abb.test
+    ~desc:"ignore an erroring query, then issue another on the same conn"
+    ~name:"ignore_error_then_query"
+    (fun () ->
+      let open Abb.Future.Infix_monad in
+      let bad_runtime = Pgsql_io.Typed_sql.(sql // Ret.integer /^ "SELECT (1 / 0)::integer") in
+      let bad_parse =
+        Pgsql_io.Typed_sql.(sql // Ret.integer /^ "SELECT x FROM definitely_missing_table_xyz")
+      in
+      let good = Pgsql_io.Typed_sql.(sql // Ret.integer /^ "SELECT 1::integer") in
+      let probe label conn bad =
+        Logs.info (fun m -> m "%s : issuing erroring query (result will be IGNORED)" label);
+        Pgsql_io.Prepared_stmt.fetch conn bad ~f:(fun n -> Int32.to_int n)
+        >>= fun res ->
+        (match res with
+        | Ok _ -> Logs.info (fun m -> m "%s : first query returned Ok (unexpected)" label)
+        | Error e ->
+            Logs.info (fun m -> m "%s : first query Error %s (IGNORED)" label (Pgsql_io.show_err e)));
+        Logs.info (fun m -> m "%s : issuing SECOND query on same conn" label);
+        Abbs_future_combinators.timeout
+          ~timeout:(Abb.Sys.sleep 12.0)
+          (Pgsql_io.Prepared_stmt.fetch conn good ~f:(fun n -> Int32.to_int n))
+        >>= function
+        | `Ok (Ok rows) ->
+            Logs.info (fun m -> m "%s : SECOND ok rows=%d (NO HANG)" label (List.length rows));
+            Abb.Future.return (Ok ())
+        | `Ok (Error e) ->
+            Logs.info (fun m -> m "%s : SECOND Error %s (NO HANG)" label (Pgsql_io.show_err e));
+            Abb.Future.return (Ok ())
+        | `Timeout ->
+            Logs.err (fun m -> m "%s : SECOND HANG : *** stalled on same conn ***" label);
+            Abb.Future.return (Ok ())
+      in
+      let in_tx label conn bad =
+        Abbs_future_combinators.timeout
+          ~timeout:(Abb.Sys.sleep 30.0)
+          (Pgsql_io.tx conn ~f:(fun () -> probe label conn bad))
+        >>= fun _ -> Abb.Future.return (Ok ())
+      in
+      with_conn (fun conn -> probe "A_NOTX_RUNTIME" conn bad_runtime)
+      >>= fun _ ->
+      with_conn (fun conn -> probe "B_NOTX_PARSE" conn bad_parse)
+      >>= fun _ ->
+      with_conn (fun conn -> in_tx "C_TX_RUNTIME" conn bad_runtime)
+      >>= fun _ ->
+      with_conn (fun conn -> in_tx "D_TX_PARSE" conn bad_parse) >>= fun _ -> Abb.Future.return ())
+
+(* Hypothesis (the real one): pgsql_io hangs inside a tx waiting for a
+   ReadyForQuery that never comes.  error_response/reset only accept a
+   ReadyForQuery whose status agrees with conn.in_tx:
+
+     | ReadyForQuery { status = 'T' | 'E' } when conn.in_tx     -> true
+     | ReadyForQuery { status = 'I' }       when not conn.in_tx -> true
+     | _ -> false
+
+   fetch/execute, by contrast, accept ANY ReadyForQuery status and never touch
+   in_tx.  So if conn.in_tx ever disagrees with the backend's real transaction
+   status, the *next statement that errors* routes into error_response, which
+   waits forever for a ReadyForQuery that will never arrive -- connection idle,
+   tx open -- exactly the 240s idle-in-transaction stall.
+
+   This test manufactures the desync (in_tx = true while the backend is at 'I')
+   and then issues a failing statement.  The point isn't the manufacturing step
+   -- it's to prove that *given a desynced in_tx*, an error is a permanent hang. *)
+let test_in_tx_commit_desync =
+  Oth_abb.test
+    ~desc:"in_tx desync + erroring stmt hangs forever in error_response"
+    ~name:"in_tx_commit_desync"
+    (fun () ->
+      let open Abb.Future.Infix_monad in
+      let f conn =
+        let commit_sql = Pgsql_io.Typed_sql.(sql /^ "COMMIT") in
+        let bad_sql = Pgsql_io.Typed_sql.(sql // Ret.integer /^ "SELECT (1 / 0)::integer") in
+        Abbs_future_combinators.timeout
+          ~timeout:(Abb.Sys.sleep 20.0)
+          (Pgsql_io.tx conn ~f:(fun () ->
+               let open Abbs_future_combinators.Infix_result_monad in
+               (* End the backend's tx behind pgsql_io's back: backend goes to
+                  'I', but conn.in_tx stays true (execute accepts any RFQ). *)
+               Pgsql_io.Prepared_stmt.execute conn commit_sql
+               >>= fun () ->
+               Logs.info (fun m ->
+                   m "DESYNC : COMMIT executed -> backend at 'I', conn.in_tx still true");
+               (* Now an erroring statement.  consume_fetch sees ErrorResponse ->
+                  error_response waits for RFQ 'T'|'E' (in_tx) but backend sends
+                  'I' -> dropped -> wait_for_frames blocks forever. *)
+               Logs.info (fun m -> m "DESYNC : issuing erroring stmt (1/0)");
+               Pgsql_io.Prepared_stmt.fetch conn bad_sql ~f:(fun n -> Int32.to_int n)
+               >>= fun _ -> Abb.Future.return (Ok ())))
+        >>= function
+        | `Ok (Ok ()) ->
+            Logs.info (fun m -> m "NO_HANG : tx completed (no desync hang)");
+            Abb.Future.return (Ok ())
+        | `Ok (Error err) ->
+            Logs.info (fun m -> m "NO_HANG : tx returned error %s" (Pgsql_io.show_err err));
+            Abb.Future.return (Ok ())
+        | `Timeout ->
+            Logs.err (fun m ->
+                m "HANG : *** error_response stuck waiting for a ReadyForQuery that never comes ***");
+            Abb.Future.return (Ok ())
+      in
+      with_conn f
+      >>= fun r ->
+      ignore (Oth.Assert.ok ~pp:pp_pgsql_combined_err r);
+      Abb.Future.return ())
+
+(* Hypothesis: the evaluator leaves the connection dirty by aborting a db op
+   mid-protocol (timeout / suspend short-circuit / orphaned parallel fetch).
+   Execute is sent, the response is never consumed, so the NEXT op on the same
+   connection inherits a desynced frame stream and stalls. This is testable on
+   plaintext and does not involve any pgsql_io bug -- it's about how the op is
+   driven. *)
+let test_desync_after_abort =
+  Oth_abb.test
+    ~desc:"Aborting a db op mid-flight leaves the connection unusable"
+    ~name:"desync_after_abort"
+    (fun () ->
+      let open Abb.Future.Infix_monad in
+      let f conn =
+        let slow_sql = Pgsql_io.Typed_sql.(sql // Ret.text /^ "SELECT pg_sleep(5)::text") in
+        let normal_sql = Pgsql_io.Typed_sql.(sql // Ret.integer /^ "SELECT 1::integer") in
+        (* op 1: slow query aborted after 0.5s (Execute on the wire, response
+           never read). *)
+        Logs.info (fun m -> m "ABORT_OP : start slow query, 0.5s timeout");
+        Abbs_future_combinators.timeout
+          ~timeout:(Abb.Sys.sleep 0.5)
+          (Pgsql_io.Prepared_stmt.fetch conn slow_sql ~f:(fun s -> s))
+        >>= fun abort_res ->
+        (match abort_res with
+        | `Timeout -> Logs.info (fun m -> m "ABORT_OP : aborted mid-flight (timed out)")
+        | `Ok (Ok _) -> Logs.info (fun m -> m "ABORT_OP : completed before timeout (no abort)")
+        | `Ok (Error err) -> Logs.info (fun m -> m "ABORT_OP : err %s" (Pgsql_io.show_err err)));
+        (* op 2: a trivial fetch on the SAME connection. Does it hang? *)
+        Logs.info (fun m -> m "NEXT_OP : start trivial fetch on same connection");
+        Abbs_future_combinators.timeout
+          ~timeout:(Abb.Sys.sleep 20.0)
+          (Pgsql_io.Prepared_stmt.fetch conn normal_sql ~f:(fun n -> Int32.to_int n))
+        >>= function
+        | `Ok (Ok rows) ->
+            Logs.info (fun m -> m "NEXT_OP : OK : rows=%d (no desync)" (List.length rows));
+            Abb.Future.return (Ok ())
+        | `Ok (Error err) ->
+            Logs.err (fun m -> m "NEXT_OP : ERR : %s (connection broke)" (Pgsql_io.show_err err));
+            Abb.Future.return (Ok ())
+        | `Timeout ->
+            Logs.err (fun m -> m "NEXT_OP : HANG : *** 20s+ STALL REPRODUCED on same conn ***");
+            Abb.Future.return (Ok ())
+      in
+      with_conn f
+      >>= fun r ->
+      ignore (Oth.Assert.ok ~pp:pp_pgsql_combined_err r);
+      Abb.Future.return ())
+
 let test =
   Oth_abb.(
     to_sync_test
       (serial
          [
+           test_ignore_error_then_query;
+           test_in_tx_commit_desync;
+           test_desync_after_abort;
+           test_large_jsonb_fetch;
            test_insert_row_null;
            test_fetch_row;
            test_fetch_all_rows;
@@ -1955,13 +2266,15 @@ let test =
            test_ret_b_all_types;
          ]))
 
+let () = ignore (pp_result_unit, test_query_dangerous_values, test_copy_to_single_row)
+
 let reporter ppf =
-  let report src level ~over k msgf =
+  let report _src level ~over k msgf =
     let k _ =
       over ();
       k ()
     in
-    let with_stamp h tags k ppf fmt =
+    let with_stamp h _tags k ppf fmt =
       (* TODO: Make this use the proper Abb time *)
       let time = Unix.gettimeofday () in
       let time_str = ISO8601.Permissive.string_of_datetime time in
@@ -1974,5 +2287,5 @@ let reporter ppf =
 let () =
   Random.self_init ();
   Logs.set_reporter (reporter Format.std_formatter);
-  Logs.set_level ~all:true (Some Logs.Debug);
+  Logs.set_level ~all:true (Some Logs.Info);
   Oth.run test


### PR DESCRIPTION
It is possible it gets stuck waiting for sync frames on error that will never come or are of a different type than it is expecting.  Fail fast and depend on the state of the DB for if in a transaction or not.

## Description

<!-- Briefly describe the changes and the issue it fixes. -->

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (explain):

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/terrateamio/terrateam/blob/main/CONTRIBUTING.md)
- [x] The pull request title follows this format:
      `ISSUE_NUMBER ACTION_TYPE Short description` (e.g., `123 ADD Feature description`)
- [x] I have added tests and documentation (if applicable)
- [x] My changes generate no new warnings/errors and do not break existing functionality

## Additional context (optional)

<!-- Add any additional context here, e.g., screenshots, dependencies, etc. -->
