### PR TITLE
#1355 ADD track repo configs

### DIFF
--- a/code/src/iris/package-lock.json
+++ b/code/src/iris/package-lock.json
@@ -3203,6 +3203,21 @@
         }
       }
     },
+    "node_modules/svelte-check/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/svelte-check/node_modules/readdirp": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",

--- a/code/src/terrat/migrations/2026-07-05-extend-repo-configs-with-history.sql
+++ b/code/src/terrat/migrations/2026-07-05-extend-repo-configs-with-history.sql
@@ -1,0 +1,55 @@
+-- Extend repo_configs so it stores two kinds of row:
+--
+--   'built'   - the existing build-config cache, keyed (installation, sha),
+--               expired after a day by the repo config cleanup loop.
+--   'derived' - a history of the fully-derived repo config (the
+--               `terrateam repo-config` output), keyed
+--               (installation, repo, branch, sha) so it can be analyzed by
+--               org/repo/branch over time, expired after 90 days by the repo
+--               config cleanup loop.
+--
+-- The two kinds have different uniqueness grains, so the single
+-- (installation, sha) primary key is replaced by a partial unique index per
+-- kind.
+
+alter table repo_configs
+      add column kind text not null default 'built',
+      add column repo uuid,
+      add column branch text;
+
+alter table repo_configs
+      drop constraint repo_configs_pkey,
+      drop constraint repo_configs_fut_pkey;
+
+create unique index repo_configs_built_key
+       on repo_configs (installation, sha)
+       where kind = 'built';
+
+create unique index repo_configs_derived_key
+       on repo_configs (installation, repo, branch, sha)
+       where kind = 'derived';
+
+-- The per-VCS build-cache views now only expose 'built' rows so the existing
+-- read path (select_repo_config.sql) never sees history rows.
+
+create or replace view github_repo_configs as
+       select
+        gim.installation_id as installation_id,
+        rc.sha as sha,
+        rc.created_at as created_at,
+        rc.data as data
+       from repo_configs as rc
+       inner join github_installations_map as gim
+             on rc.installation = gim.core_id
+       where rc.kind = 'built';
+
+create or replace view gitlab_repo_configs as
+       select
+        gim.installation_id as installation_id,
+        rc.sha as sha,
+        rc.created_at as created_at,
+        rc.data as data
+       from repo_configs as rc
+       inner join gitlab_installations_map as gim
+             on rc.installation = gim.core_id
+       where rc.kind = 'built';

--- a/code/src/terrat/terrat_migrations.ml
+++ b/code/src/terrat/terrat_migrations.ml
@@ -277,6 +277,8 @@ let migrations =
     ("add-drift-branch", run_sql [%blob "migrations/2026-01-08-add-drift-branch.sql"]);
     ( "delete-existing-repo-tree-cache",
       run_sql [%blob "migrations/2026-03-19-delete-repo-tree-cache.sql"] );
+    ( "extend-repo-configs-with-history",
+      run_sql [%blob "migrations/2026-07-05-extend-repo-configs-with-history.sql"] );
   ]
 
 let run config storage = Mig.run { Migrate.config; storage; tx = () } migrations

--- a/code/src/terrat_vcs_event_evaluator2/terrat_vcs_event_evaluator2_tasks.ml
+++ b/code/src/terrat_vcs_event_evaluator2/terrat_vcs_event_evaluator2_tasks.ml
@@ -128,8 +128,34 @@ struct
           | Error (#Terrat_kv_store.err as err) -> Abb.Future.return (Error err))
       | Error _ as err -> Abb.Future.return err
 
+    (* Persist the fully-derived config to the repo_configs history so it can be
+       analyzed by org/repo/branch over time. Failures here must not fail the
+       evaluation, so errors are logged and swallowed. *)
+    let write_config_history ~account ~repo ~branch ~sha repo_config_json s =
+      let open Abb.Future.Infix_monad in
+      Builder.run_db s ~f:(fun db ->
+          S.Db.store_repo_config_history
+            ~request_id:(Builder.log_id s)
+            db
+            account
+            repo
+            ~branch
+            ~sha
+            repo_config_json)
+      >>= function
+      | Ok () | Error `Closed -> Abb.Future.return (Ok ())
+      | Error (#Builder.err as err) ->
+          Logs.err (fun m ->
+              m "%s : RECORD_REPO_CONFIG_HISTORY : %a" (Builder.log_id s) Builder.pp_err err);
+          Abb.Future.return (Ok ())
+
+    (* [record_history] carries the (account, repo, branch) identity to snapshot
+       the derived config under. It is [Some] only on the full-index derive
+       paths, so an empty-index intermediate never overwrites the canonical
+       config for a given (repo, branch, sha). *)
     let derive
         ~cache_key
+        ~record_history
         ~dest_branch_name
         ~branch_name
         ~branch_ref
@@ -159,17 +185,21 @@ struct
                 ~file_list:repo_tree
                 repo_config_raw))
       >>= fun repo_config ->
-      Builder.run_db
-        s
-        ~f:
-          (store
-             ~cache_key
-             (Terrat_repo_config.Version_1.to_yojson
-             @@ Terrat_base_repo_config_v1.to_version_1 repo_config))
-      >>= fun _ -> Abb.Future.return (Ok repo_config)
+      let repo_config_json =
+        Terrat_repo_config.Version_1.to_yojson
+        @@ Terrat_base_repo_config_v1.to_version_1 repo_config
+      in
+      Builder.run_db s ~f:(store ~cache_key repo_config_json)
+      >>= fun _ ->
+      (match record_history with
+        | Some (account, repo, branch) ->
+            write_config_history ~account ~repo ~branch ~sha:branch_ref repo_config_json s
+        | None -> Abb.Future.return (Ok ()))
+      >>= fun () -> Abb.Future.return (Ok repo_config)
 
     let derived_repo_config
         ~cache_key
+        ~record_history
         ~dest_branch_name
         ~branch_name
         ~branch_ref
@@ -194,6 +224,7 @@ struct
                     err);
               derive
                 ~cache_key
+                ~record_history
                 ~dest_branch_name
                 ~branch_name
                 ~branch_ref
@@ -204,6 +235,7 @@ struct
       | None ->
           derive
             ~cache_key
+            ~record_history
             ~dest_branch_name
             ~branch_name
             ~branch_ref
@@ -1256,6 +1288,7 @@ struct
           in
           Cache.derived_repo_config
             ~cache_key
+            ~record_history:None
             ~dest_branch_name
             ~branch_name
             ~branch_ref
@@ -1293,6 +1326,7 @@ struct
           in
           Cache.derived_repo_config
             ~cache_key
+            ~record_history:(Some (account, repo, branch_name))
             ~dest_branch_name
             ~branch_name
             ~branch_ref
@@ -1428,6 +1462,7 @@ struct
           in
           Cache.derived_repo_config
             ~cache_key
+            ~record_history:None
             ~dest_branch_name
             ~branch_name
             ~branch_ref:dest_branch_ref
@@ -1465,6 +1500,7 @@ struct
           in
           Cache.derived_repo_config
             ~cache_key
+            ~record_history:(Some (account, repo, dest_branch_name))
             ~dest_branch_name
             ~branch_name
             ~branch_ref:dest_branch_ref

--- a/code/src/terrat_vcs_provider2/terrat_vcs_provider2.ml
+++ b/code/src/terrat_vcs_provider2/terrat_vcs_provider2.ml
@@ -234,6 +234,16 @@ module type S = sig
       Yojson.Safe.t ->
       (unit, [> `Error ]) result Abb.Future.t
 
+    val store_repo_config_history :
+      request_id:string ->
+      t ->
+      Api.Account.t ->
+      Api.Repo.t ->
+      branch:Api.Ref.t ->
+      sha:Api.Ref.t ->
+      Yojson.Safe.t ->
+      (unit, [> `Error ]) result Abb.Future.t
+
     val store_repo_tree :
       request_id:string ->
       t ->

--- a/code/src/terrat_vcs_provider2_nyi/terrat_vcs_provider2_nyi.ml
+++ b/code/src/terrat_vcs_provider2_nyi/terrat_vcs_provider2_nyi.ml
@@ -22,6 +22,10 @@ module Db = struct
   let store_index ~request_id db work_manifest_id index = raise (Failure "nyi")
   let store_index_result ~request_id db work_manifest_id index_result = raise (Failure "nyi")
   let store_repo_config_json ~request_id db account ref_ json = raise (Failure "nyi")
+
+  let store_repo_config_history ~request_id db account repo ~branch ~sha json =
+    raise (Failure "nyi")
+
   let store_repo_tree ~request_id db account ref_ files = raise (Failure "nyi")
   let store_flow_state ~request_id db work_manifest_id state = raise (Failure "nyi")
 

--- a/code/src/terrat_vcs_service_github/sql/cleanup_repo_configs.sql
+++ b/code/src/terrat_vcs_service_github/sql/cleanup_repo_configs.sql
@@ -1,1 +1,3 @@
-delete from repo_configs where (now() - created_at) > interval '1 day'
+delete from repo_configs
+where (kind = 'built' and (now() - created_at) > interval '1 day')
+   or (kind = 'derived' and (now() - created_at) > interval '90 days')

--- a/code/src/terrat_vcs_service_github/sql/delete_repo.sql
+++ b/code/src/terrat_vcs_service_github/sql/delete_repo.sql
@@ -127,6 +127,11 @@ delete_change_dirspaces as (
     using repo as r
     where change_dirspaces.repo = r.core_id
 ),
+delete_repo_configs as (
+    delete from repo_configs
+    using repo as r
+    where repo_configs.repo = r.core_id
+),
 delete_drift_schedules as (
     delete from drift_schedules
     using repo as r

--- a/code/src/terrat_vcs_service_github/sql/insert_repo_config.sql
+++ b/code/src/terrat_vcs_service_github/sql/insert_repo_config.sql
@@ -5,5 +5,5 @@ select
         gim.core_id
 from github_installations_map as gim
 where gim.installation_id = $installation_id
-on conflict on constraint repo_configs_pkey
+on conflict (installation, sha) where kind = 'built'
 do update set data = excluded.data

--- a/code/src/terrat_vcs_service_github/sql/insert_repo_config_history.sql
+++ b/code/src/terrat_vcs_service_github/sql/insert_repo_config_history.sql
@@ -1,0 +1,14 @@
+insert into repo_configs (installation, repo, branch, sha, data, kind)
+select
+        gim.core_id,
+        grm.core_id,
+        $branch,
+        $sha,
+        $data,
+        'derived'
+from github_installations_map as gim
+inner join github_repositories_map as grm
+      on grm.repository_id = $repository_id
+where gim.installation_id = $installation_id
+on conflict (installation, repo, branch, sha) where kind = 'derived'
+do update set data = excluded.data

--- a/code/src/terrat_vcs_service_github/terrat_vcs_service_github_provider.ml
+++ b/code/src/terrat_vcs_service_github/terrat_vcs_service_github_provider.ml
@@ -337,6 +337,16 @@ module Db = struct
         /% Var.text "sha"
         /% Var.json "data")
 
+    let insert_repo_config_history =
+      Pgsql_io.Typed_sql.(
+        sql
+        /^ read [%blob "sql/insert_repo_config_history.sql"]
+        /% Var.text "branch"
+        /% Var.text "sha"
+        /% Var.json "data"
+        /% Var.bigint "repository_id"
+        /% Var.bigint "installation_id")
+
     let insert_repo_tree =
       Pgsql_io.Typed_sql.(
         sql
@@ -1216,6 +1226,24 @@ module Db = struct
           (CCInt64.of_int @@ Api.Account.id account)
           (Api.Ref.to_string ref_)
           json)
+    >>= function
+    | Ok () -> Abb.Future.return (Ok ())
+    | Error (#Pgsql_io.err as err) ->
+        Prmths.Counter.inc_one Metrics.pgsql_errors_total;
+        Logs.err (fun m -> m "%s : ERROR : %a" request_id Pgsql_io.pp_err err);
+        Abb.Future.return (Error `Error)
+
+  let store_repo_config_history ~request_id db account repo ~branch ~sha json =
+    let open Abb.Future.Infix_monad in
+    Metrics.Psql_query_time.time (Metrics.psql_query_time "insert_repo_config_history") (fun () ->
+        Pgsql_io.Prepared_stmt.execute
+          db
+          Sql.insert_repo_config_history
+          (Api.Ref.to_string branch)
+          (Api.Ref.to_string sha)
+          json
+          (CCInt64.of_int @@ Api.Repo.id repo)
+          (CCInt64.of_int @@ Api.Account.id account))
     >>= function
     | Ok () -> Abb.Future.return (Ok ())
     | Error (#Pgsql_io.err as err) ->

--- a/code/src/terrat_vcs_service_gitlab/sql/cleanup_repo_configs.sql
+++ b/code/src/terrat_vcs_service_gitlab/sql/cleanup_repo_configs.sql
@@ -1,1 +1,3 @@
-delete from repo_configs where (now() - created_at) > interval '1 day'
+delete from repo_configs
+where (kind = 'built' and (now() - created_at) > interval '1 day')
+   or (kind = 'derived' and (now() - created_at) > interval '90 days')

--- a/code/src/terrat_vcs_service_gitlab/sql/delete_repo.sql
+++ b/code/src/terrat_vcs_service_gitlab/sql/delete_repo.sql
@@ -120,6 +120,11 @@ delete_change_dirspaces as (
     using repo as r
     where change_dirspaces.repo = r.core_id
 ),
+delete_repo_configs as (
+    delete from repo_configs
+    using repo as r
+    where repo_configs.repo = r.core_id
+),
 delete_drift_schedules as (
     delete from drift_schedules
     using repo as r

--- a/code/src/terrat_vcs_service_gitlab/sql/insert_repo_config.sql
+++ b/code/src/terrat_vcs_service_gitlab/sql/insert_repo_config.sql
@@ -5,5 +5,5 @@ select
         gim.core_id
 from gitlab_installations_map as gim
 where gim.installation_id = $installation_id
-on conflict on constraint repo_configs_pkey
+on conflict (installation, sha) where kind = 'built'
 do update set data = excluded.data

--- a/code/src/terrat_vcs_service_gitlab/sql/insert_repo_config_history.sql
+++ b/code/src/terrat_vcs_service_gitlab/sql/insert_repo_config_history.sql
@@ -1,0 +1,14 @@
+insert into repo_configs (installation, repo, branch, sha, data, kind)
+select
+        gim.core_id,
+        grm.core_id,
+        $branch,
+        $sha,
+        $data,
+        'derived'
+from gitlab_installations_map as gim
+inner join gitlab_repositories_map as grm
+      on grm.repository_id = $repository_id
+where gim.installation_id = $installation_id
+on conflict (installation, repo, branch, sha) where kind = 'derived'
+do update set data = excluded.data

--- a/code/src/terrat_vcs_service_gitlab/terrat_vcs_service_gitlab_provider.ml
+++ b/code/src/terrat_vcs_service_gitlab/terrat_vcs_service_gitlab_provider.ml
@@ -337,6 +337,16 @@ module Db = struct
         /% Var.text "sha"
         /% Var.json "data")
 
+    let insert_repo_config_history =
+      Pgsql_io.Typed_sql.(
+        sql
+        /^ read [%blob "sql/insert_repo_config_history.sql"]
+        /% Var.text "branch"
+        /% Var.text "sha"
+        /% Var.json "data"
+        /% Var.bigint "repository_id"
+        /% Var.bigint "installation_id")
+
     let insert_repo_tree =
       Pgsql_io.Typed_sql.(
         sql
@@ -1215,6 +1225,24 @@ module Db = struct
           (CCInt64.of_int @@ Api.Account.id account)
           (Api.Ref.to_string ref_)
           json)
+    >>= function
+    | Ok () -> Abb.Future.return (Ok ())
+    | Error (#Pgsql_io.err as err) ->
+        Prmths.Counter.inc_one Metrics.pgsql_errors_total;
+        Logs.err (fun m -> m "%s : ERROR : %a" request_id Pgsql_io.pp_err err);
+        Abb.Future.return (Error `Error)
+
+  let store_repo_config_history ~request_id db account repo ~branch ~sha json =
+    let open Abb.Future.Infix_monad in
+    Metrics.Psql_query_time.time (Metrics.psql_query_time "insert_repo_config_history") (fun () ->
+        Pgsql_io.Prepared_stmt.execute
+          db
+          Sql.insert_repo_config_history
+          (Api.Ref.to_string branch)
+          (Api.Ref.to_string sha)
+          json
+          (CCInt64.of_int @@ Api.Repo.id repo)
+          (CCInt64.of_int @@ Api.Account.id account))
     >>= function
     | Ok () -> Abb.Future.return (Ok ())
     | Error (#Pgsql_io.err as err) ->


### PR DESCRIPTION
Closes #1355

Tracks every fully-derived repo config (the `terrateam repo-config` output) so it can be analyzed by org/repo/branch over time. Rather than a new table, this **extends the existing `repo_configs` table** to hold two kinds of row.

## Schema (`repo_configs`)
- New `kind` column: `'built'` (the existing build-config cache, keyed `(installation, sha)`, expired after a day) and `'derived'` (the new permanent history, keyed `(installation, repo, branch, sha)`).
- New `repo uuid`, `branch text` columns.
- The single `(installation, sha)` primary key is replaced by two **partial unique indexes**, one per kind, so a commit can be both build-cached and derived-tracked without colliding.
- The `github_repo_configs`/`gitlab_repo_configs` build-cache views and the hourly cleanup now filter `kind = 'built'`, so the existing read/expiry path is unchanged and derived history is never purged.

## Write path
- New `S.Db.store_repo_config_history` (GitHub + GitLab, plus nyi stub), upserting a derived row keyed `(installation, repo, branch, sha)`.
- Written from `Cache.derive` in the event evaluator — only on the **full-index** derive paths (branch and dest-branch), so an empty-index intermediate never overwrites the canonical config. Fires on derivation (KV-cache miss); re-deriving the same commit is an idempotent upsert. Failures are logged and swallowed so history recording never fails an evaluation.
- `delete_repo.sql` (both providers) clears the repo's derived rows so a deleted repo leaves no orphaned history.

## Why extend rather than add a table
`repo_configs` already stores a per-sha JSON config blob; reusing it keeps a single config table and lets derived history reuse the existing `sha` column (one row per commit per branch) instead of a bespoke digest scheme. The `built`/`derived` split keeps the ephemeral build cache and the permanent history cleanly separated. Analysts read the derived history straight from `repo_configs` with `where kind = 'derived'`.

## Verification
- `terrat_oss`/`terrat_ee` build; `make test-terrat` passes (55/55, 2/2, 48/48).
- Migration + both providers' real insert/cleanup/delete SQL exercised verbatim against Postgres 17: built/derived rows coexist on a shared sha, on-conflict upserts dedupe, cleanup and the build-cache views partition correctly by kind and VCS, and repo-delete removes only derived rows.