### PR TITLE
#1370 ADD docs for INFRACOST_CONFIG_FILE

### DIFF
--- a/docs/src/content/docs/integrations/external-tools/infracost.mdx
+++ b/docs/src/content/docs/integrations/external-tools/infracost.mdx
@@ -67,6 +67,9 @@ Set the currency for the cost estimates. This overrides the `currency` setting i
 ##### `INFRACOST_ARGS`
 Pass additional arguments to the `infracost` command. For example, you can use `--show-skipped` to include resources that were skipped in the cost estimate.
 
+##### `INFRACOST_CONFIG_FILE`
+Use your own Infracost [config file](https://www.infracost.io/docs/features/config_file/) instead of the one Terrateam generates. Set it to a path relative to the repository root (or absolute). If the file is missing on a branch — such as the base branch used to compute the previous cost — Terrateam falls back to the generated config.
+
 ## Viewing Cost Estimates
 
 When Terrateam generates a cost estimate for a pull request, it will add a comment to the pull request with the following information:

--- a/docs/src/content/docs/reference/configuration/cost-estimation.mdx
+++ b/docs/src/content/docs/reference/configuration/cost-estimation.mdx
@@ -46,6 +46,7 @@ Terrateam supports the following Infracost environment variables:
 |------|-------------|
 | `INFRACOST_API_KEY` | User's Infracost API key. [Sign up](https://www.infracost.io/) and navigate to the `Org Settings` page to get your free Infracost API key. |
 | `INFRACOST_CURRENCY` | An [ISO 4217](https://en.wikipedia.org/wiki/ISO_4217#Active_codes) currency code to report results. The value in the repository configuration takes precedence. |
+| `INFRACOST_CONFIG_FILE` | Path to a custom Infracost [config file](https://www.infracost.io/docs/features/config_file/) to use instead of the one Terrateam generates. Relative paths are resolved from the repository root. |
 
 ## Examples
 ### Enable Cost Estimation with Default Settings
@@ -69,3 +70,15 @@ cost_estimation:
   currency: EUR
 ```
 This configuration will enable cost estimation and report results in Euros (EUR).
+
+### Use a Custom Infracost Config File
+By default Terrateam generates an Infracost [config file](https://www.infracost.io/docs/features/config_file/) listing the directories and workspaces being run. To use your own instead, set the `INFRACOST_CONFIG_FILE` environment variable to its path. The value can be set with an [`env` hook](/reference/configuration/hooks):
+```yaml
+hooks:
+  plan:
+    pre:
+      - type: env
+        name: INFRACOST_CONFIG_FILE
+        cmd: ["echo", "infracost.yml"]
+```
+The path is relative to the repository root (or absolute). If the file does not exist on a given branch — for example the base branch used to compute the previous cost — Terrateam falls back to the config it generates.


### PR DESCRIPTION
## Description

Document the `INFRACOST_CONFIG_FILE` environment variable for supplying a custom Infracost config file. Pairs with terrateamio/action#611.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (explain):

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/terrateamio/terrateam/blob/main/CONTRIBUTING.md)
- [x] The pull request title follows this format:
      `ISSUE_NUMBER ACTION_TYPE Short description` (e.g., `123 ADD Feature description`)
- [x] I have added tests and documentation (if applicable)
- [ ] My changes generate no new warnings/errors and do not break existing functionality

## Additional context (optional)

<!-- Add any additional context here, e.g., screenshots, dependencies, etc. -->