### PR TITLE
#1359 FIX Console "view outputs" link points at the PR's runs page

### DIFF
--- a/code/src/iris/src/lib/RunsPRDetail.svelte
+++ b/code/src/iris/src/lib/RunsPRDetail.svelte
@@ -25,6 +25,11 @@
 
   $: prNumber = params.prNumber ? parseInt(params.prNumber) : null;
 
+  // Only surface the Stacks section when the pull request actually has stacks.
+  // Reviewers arriving from a pull request comment want the runs; an empty
+  // stacks tree is surprising noise.
+  $: hasStacks = (stacks?.stacks?.length ?? 0) > 0;
+
   // Check if user came from a specific run detail page
   let lastRunId: string | null = null;
   $: if (typeof window !== 'undefined') {
@@ -343,12 +348,14 @@
             View on {$currentVCSProvider === 'github' ? 'GitHub' : 'GitLab'}
           </Button>
         {/if}
-        <Button variant="outline" size="md" on:click={handleRefreshStacks}>
-          <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
-          </svg>
-          Refresh Stacks
-        </Button>
+        {#if hasStacks}
+          <Button variant="outline" size="md" on:click={handleRefreshStacks}>
+            <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+            </svg>
+            Refresh Stacks
+          </Button>
+        {/if}
         <Button variant="outline" size="md" on:click={handleRefreshRuns}>
           <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
@@ -357,21 +364,6 @@
         </Button>
       </div>
     </Card>
-
-    <!-- Stacks Section -->
-    <div class="mb-6">
-      <div class="flex items-center justify-between mb-4">
-        <h2 class="text-xl font-semibold text-[var(--sg-text)]">
-          Infrastructure Stacks
-        </h2>
-      </div>
-
-      <StackTree
-        {stacks}
-        loading={isStacksLoading}
-        error={stacksError}
-      />
-    </div>
 
     <!-- Runs Section -->
     <div class="mb-6">
@@ -472,5 +464,22 @@
         </Card>
       {/if}
     </div>
+
+    {#if hasStacks}
+      <!-- Stacks Section -->
+      <div class="mb-6">
+        <div class="flex items-center justify-between mb-4">
+          <h2 class="text-xl font-semibold text-[var(--sg-text)]">
+            Infrastructure Stacks
+          </h2>
+        </div>
+
+        <StackTree
+          {stacks}
+          loading={isStacksLoading}
+          error={stacksError}
+        />
+      </div>
+    {/if}
   {/if}
 </PageLayout>

--- a/code/src/terrat_vcs_github_comment/terrat_vcs_github_comment.ml
+++ b/code/src/terrat_vcs_github_comment/terrat_vcs_github_comment.ml
@@ -236,17 +236,38 @@ module S = struct
     let request_id = t.request_id in
     Api.minimize_pull_request_comment ~request_id t.client t.pull_request comment_id
 
+  (* Link to the PR-level runs page so the comment (which aggregates every work
+     manifest for the pull request) points at all of them, not just the last one
+     to post. *)
+  let pull_number t = Some (Api.Pull_request.id t.pull_request)
+
+  (* Per-dirspace deep links to the specific work manifest run that produced each
+     dirspace's output. *)
+  let dirspace_run_urls t els =
+    CCList.filter_map
+      (fun el ->
+        match
+          Ui.run_url t.config t.work_manifest.Terrat_work_manifest3.account el.work_manifest_id
+        with
+        | Some uri -> Some (el.dirspace, Uri.to_string uri)
+        | None -> None)
+      els
+
   let post_comment t els =
     let open Abb.Future.Infix_monad in
     let module R2 = Terrat_api_components.Work_manifest_tf_operation_result2 in
     (* TODO: Stop using the result, move gates to to t *)
     let gates = t.result.R2.gates in
+    let pull_number = pull_number t in
+    let dirspace_run_urls = dirspace_run_urls t els in
     let by_dirspace = CCList.map (fun el -> (Scope.Dirspace el.dirspace, el.steps)) els in
     let by_scope = t.hooks @ by_dirspace in
     let compact = CCList.exists (fun { compact; _ } -> compact) els in
     let body =
       Publisher_tools.create_run_output
         ~view:(if compact then `Compact else `Full)
+        ~pull_number
+        ~dirspace_run_urls
         t.request_id
         t.account_status
         t.tier_runs
@@ -268,6 +289,8 @@ module S = struct
         let body =
           Publisher_tools.create_run_output
             ~view:`Compact
+            ~pull_number
+            ~dirspace_run_urls
             t.request_id
             t.account_status
             t.tier_runs
@@ -289,6 +312,8 @@ module S = struct
             let body =
               Publisher_tools.create_run_output
                 ~view:`Compact
+                ~pull_number
+                ~dirspace_run_urls
                 t.request_id
                 t.account_status
                 t.tier_runs
@@ -307,12 +332,16 @@ module S = struct
   let rendered_length t els =
     let module R2 = Terrat_api_components.Work_manifest_tf_operation_result2 in
     let gates = t.result.R2.gates in
+    let pull_number = pull_number t in
+    let dirspace_run_urls = dirspace_run_urls t els in
     let by_dirspace = CCList.map (fun el -> (Scope.Dirspace el.dirspace, el.steps)) els in
     let by_scope = t.hooks @ by_dirspace in
     let compact = CCList.exists (fun { compact; _ } -> compact) els in
     let body =
       Publisher_tools.create_run_output
         ~view:(if compact then `Compact else `Full)
+        ~pull_number
+        ~dirspace_run_urls
         t.request_id
         t.account_status
         t.tier_runs

--- a/code/src/terrat_vcs_github_comment/terrat_vcs_github_comment_publishers.ml
+++ b/code/src/terrat_vcs_github_comment/terrat_vcs_github_comment_publishers.ml
@@ -304,6 +304,8 @@ end
 module Publisher_tools = struct
   let create_run_output
       ~view
+      ~pull_number
+      ~dirspace_run_urls
       request_id
       account_status
       tier_runs
@@ -397,7 +399,7 @@ module Publisher_tools = struct
                ~default:[]
                (fun work_manifest_url ->
                  [ ("work_manifest_url", `String (Uri.to_string work_manifest_url)) ])
-               (Ui.work_manifest_url config work_manifest.Wm.account work_manifest);
+               (Ui.work_manifest_url config work_manifest.Wm.account pull_number work_manifest);
              CCOption.map_or
                ~default:[]
                (fun env -> [ ("environment", `String env) ])
@@ -443,9 +445,19 @@ module Publisher_tools = struct
                ( "dirspaces",
                  `List
                    (CCList.map
-                      (fun ({ Terrat_dirspace.dir; workspace }, steps) ->
+                      (fun (({ Terrat_dirspace.dir; workspace } as dirspace), steps) ->
                         let has_changes = steps_has_changes steps in
                         let success = steps_success steps in
+                        let run_url =
+                          match
+                            CCList.assoc_opt
+                              ~eq:(fun a b -> Terrat_dirspace.compare a b = 0)
+                              dirspace
+                              dirspace_run_urls
+                          with
+                          | Some url -> `String url
+                          | None -> `Null
+                        in
                         `Assoc
                           (CCList.flatten
                              [
@@ -458,6 +470,7 @@ module Publisher_tools = struct
                                      (kv_of_outputs
                                         (Output.filter ~overall_success (output_of_steps steps))) );
                                  ("has_changes", `Bool has_changes);
+                                 ("run_url", run_url);
                                ];
                              ]))
                       dirspaces) );

--- a/code/src/terrat_vcs_github_comment/terrat_vcs_github_comment_publishers.mli
+++ b/code/src/terrat_vcs_github_comment/terrat_vcs_github_comment_publishers.mli
@@ -38,6 +38,8 @@ end
 module Publisher_tools : sig
   val create_run_output :
     view:[> `Compact ] ->
+    pull_number:int option ->
+    dirspace_run_urls:(Terrat_dirspace.t * string) list ->
     string ->
     [< `Active | `Disabled | `Expired | `Trial_ending of int64 > `Trial_ending ] ->
     Terrat_tier.Check.runs_per_month option ->

--- a/code/src/terrat_vcs_github_comment/terrat_vcs_github_comment_ui.ml
+++ b/code/src/terrat_vcs_github_comment/terrat_vcs_github_comment_ui.ml
@@ -1,13 +1,31 @@
 module Ui = struct
   module Api = Terrat_vcs_api_github
 
-  let work_manifest_url config account work_manifest =
+  let base_url config account =
+    Printf.sprintf
+      "%s/i/%d"
+      (Uri.to_string (Terrat_config.terrateam_web_base_url @@ Api.Config.config config))
+      (Api.Account.id account)
+
+  (* For pull request runs, link to the PR-level runs page which lists every run
+     for the pull request.  For non-pull-request targets (e.g. drift), which have
+     no pull request to aggregate, fall back to the single work manifest's run. *)
+  let work_manifest_url config account pull_number work_manifest =
     let module Wm = Terrat_work_manifest3 in
+    let url =
+      match pull_number with
+      | Some pull_number -> Printf.sprintf "%s/runs/pr/%d" (base_url config account) pull_number
+      | None ->
+          Printf.sprintf
+            "%s/runs/%s"
+            (base_url config account)
+            (Uuidm.to_string work_manifest.Wm.id)
+    in
+    Some (Uri.of_string url)
+
+  (* Link to a specific work manifest's run detail. *)
+  let run_url config account work_manifest_id =
     Some
       (Uri.of_string
-         (Printf.sprintf
-            "%s/i/%d/runs/%s"
-            (Uri.to_string (Terrat_config.terrateam_web_base_url @@ Api.Config.config config))
-            (Api.Account.id account)
-            (Uuidm.to_string work_manifest.Wm.id)))
+         (Printf.sprintf "%s/runs/%s" (base_url config account) (Uuidm.to_string work_manifest_id)))
 end

--- a/code/src/terrat_vcs_github_comment/terrat_vcs_github_comment_ui.mli
+++ b/code/src/terrat_vcs_github_comment/terrat_vcs_github_comment_ui.mli
@@ -2,6 +2,10 @@ module Ui : sig
   val work_manifest_url :
     Terrat_vcs_api_github.Config.t ->
     Terrat_vcs_api_github.Account.t ->
+    int option ->
     ('a, Uuidm.t, 'b, 'c, 'd, 'e, 'f, 'g) Terrat_work_manifest3.t ->
     Uri.t option
+
+  val run_url :
+    Terrat_vcs_api_github.Config.t -> Terrat_vcs_api_github.Account.t -> Uuidm.t -> Uri.t option
 end

--- a/code/src/terrat_vcs_github_comment_templates/tmpl/apply_complete2.tmpl
+++ b/code/src/terrat_vcs_github_comment_templates/tmpl/apply_complete2.tmpl
@@ -126,7 +126,7 @@ No output shown due to comment size.
 {%- endif %}
 {%- for d in dirspaces %}
 
-## {{ d.dir }} | {{ d.workspace }} | {% if d.success %}:white_check_mark:{% else %}:heavy_multiplication_x:{% endif %}
+## {% if d.run_url %}[{{ d.dir }} | {{ d.workspace }}]({{ d.run_url }}){% else %}{{ d.dir }} | {{ d.workspace }}{% endif %} | {% if d.success %}:white_check_mark:{% else %}:heavy_multiplication_x:{% endif %}
   {%- if compact_dirspaces %}
 
 <details>

--- a/code/src/terrat_vcs_github_comment_templates/tmpl/plan_complete2.tmpl
+++ b/code/src/terrat_vcs_github_comment_templates/tmpl/plan_complete2.tmpl
@@ -188,7 +188,7 @@ No output shown due to comment size.
 {%- endif %}
 {%- for d in dirspaces %}
 
-## {{ d.dir }} | {{ d.workspace }} | {% if d.success %}{% if d.has_changes is defined and d.has_changes %}Success {% if compact_view %}:eyes:{% else %}:thumbsup:{% endif %}{% elif d.has_changes is defined and not d.has_changes %}No changes{% endif %}{% else %}:heavy_multiplication_x:{% endif %}
+## {% if d.run_url %}[{{ d.dir }} | {{ d.workspace }}]({{ d.run_url }}){% else %}{{ d.dir }} | {{ d.workspace }}{% endif %} | {% if d.success %}{% if d.has_changes is defined and d.has_changes %}Success {% if compact_view %}:eyes:{% else %}:thumbsup:{% endif %}{% elif d.has_changes is defined and not d.has_changes %}No changes{% endif %}{% else %}:heavy_multiplication_x:{% endif %}
   {%- if compact_dirspaces %}
 <details>
   <summary>Expand for details</summary>

--- a/code/src/terrat_vcs_gitlab_comment/terrat_vcs_gitlab_comment.ml
+++ b/code/src/terrat_vcs_gitlab_comment/terrat_vcs_gitlab_comment.ml
@@ -56,18 +56,27 @@ module S = struct
   let upsert_comment_id _t _els _cid = Abb.Future.return (Ok ())
   let delete_comment _t _comment_id = raise (Failure "nyi")
   let minimize_comment _t _comment_id = raise (Failure "nyi")
+  let pull_number t = Some (Api.Pull_request.id t.pull_request)
+
+  (* GitLab has no Console run pages (see [Ui.run_url]) and does not yet track a
+     per-dirspace work manifest id, so there are no per-dirspace run links. *)
+  let dirspace_run_urls _t _els = []
 
   let post_comment t els =
     let open Abb.Future.Infix_monad in
     let module R2 = Terrat_api_components.Work_manifest_tf_operation_result2 in
     (* TODO: Stop using the result, move gates to to t *)
     let gates = t.result.R2.gates in
+    let pull_number = pull_number t in
+    let dirspace_run_urls = dirspace_run_urls t els in
     let by_dirspace = CCList.map (fun el -> (Scope.Dirspace el.dirspace, el.steps)) els in
     let by_scope = t.hooks @ by_dirspace in
     let compact = CCList.exists (fun { compact; _ } -> compact) els in
     let body =
       Publisher_tools.create_run_output
         ~view:(if compact then `Compact else `Full)
+        ~pull_number
+        ~dirspace_run_urls
         t.request_id
         t.account_status
         t.tier_runs
@@ -89,6 +98,8 @@ module S = struct
         let body =
           Publisher_tools.create_run_output
             ~view:`Compact
+            ~pull_number
+            ~dirspace_run_urls
             t.request_id
             t.account_status
             t.tier_runs
@@ -110,6 +121,8 @@ module S = struct
             let body =
               Publisher_tools.create_run_output
                 ~view:`Compact
+                ~pull_number
+                ~dirspace_run_urls
                 t.request_id
                 t.account_status
                 t.tier_runs
@@ -128,12 +141,16 @@ module S = struct
   let rendered_length t els =
     let module R2 = Terrat_api_components.Work_manifest_tf_operation_result2 in
     let gates = t.result.R2.gates in
+    let pull_number = pull_number t in
+    let dirspace_run_urls = dirspace_run_urls t els in
     let by_dirspace = CCList.map (fun el -> (Scope.Dirspace el.dirspace, el.steps)) els in
     let by_scope = t.hooks @ by_dirspace in
     let compact = CCList.exists (fun { compact; _ } -> compact) els in
     let body =
       Publisher_tools.create_run_output
         ~view:(if compact then `Compact else `Full)
+        ~pull_number
+        ~dirspace_run_urls
         t.request_id
         t.account_status
         t.tier_runs

--- a/code/src/terrat_vcs_gitlab_comment/terrat_vcs_gitlab_comment_publishers.ml
+++ b/code/src/terrat_vcs_gitlab_comment/terrat_vcs_gitlab_comment_publishers.ml
@@ -306,6 +306,8 @@ end
 module Publisher_tools = struct
   let create_run_output
       ~view
+      ~pull_number
+      ~dirspace_run_urls
       request_id
       account_status
       tier_runs
@@ -399,7 +401,7 @@ module Publisher_tools = struct
                ~default:[]
                (fun work_manifest_url ->
                  [ ("work_manifest_url", `String (Uri.to_string work_manifest_url)) ])
-               (Ui.work_manifest_url config work_manifest.Wm.account work_manifest);
+               (Ui.work_manifest_url config work_manifest.Wm.account pull_number work_manifest);
              CCOption.map_or
                ~default:[]
                (fun env -> [ ("environment", `String env) ])
@@ -445,9 +447,19 @@ module Publisher_tools = struct
                ( "dirspaces",
                  `List
                    (CCList.map
-                      (fun ({ Terrat_dirspace.dir; workspace }, steps) ->
+                      (fun (({ Terrat_dirspace.dir; workspace } as dirspace), steps) ->
                         let has_changes = steps_has_changes steps in
                         let success = steps_success steps in
+                        let run_url =
+                          match
+                            CCList.assoc_opt
+                              ~eq:(fun a b -> Terrat_dirspace.compare a b = 0)
+                              dirspace
+                              dirspace_run_urls
+                          with
+                          | Some url -> `String url
+                          | None -> `Null
+                        in
                         `Assoc
                           (CCList.flatten
                              [
@@ -460,6 +472,7 @@ module Publisher_tools = struct
                                      (kv_of_outputs
                                         (Output.filter ~overall_success (output_of_steps steps))) );
                                  ("has_changes", `Bool has_changes);
+                                 ("run_url", run_url);
                                ];
                              ]))
                       dirspaces) );

--- a/code/src/terrat_vcs_gitlab_comment/terrat_vcs_gitlab_comment_publishers.mli
+++ b/code/src/terrat_vcs_gitlab_comment/terrat_vcs_gitlab_comment_publishers.mli
@@ -38,6 +38,8 @@ end
 module Publisher_tools : sig
   val create_run_output :
     view:[> `Compact ] ->
+    pull_number:int option ->
+    dirspace_run_urls:(Terrat_dirspace.t * string) list ->
     string ->
     [< `Active | `Disabled | `Expired | `Trial_ending of int64 > `Trial_ending ] ->
     Terrat_tier.Check.runs_per_month option ->

--- a/code/src/terrat_vcs_gitlab_comment/terrat_vcs_gitlab_comment_ui.ml
+++ b/code/src/terrat_vcs_gitlab_comment/terrat_vcs_gitlab_comment_ui.ml
@@ -1,3 +1,4 @@
 module Ui = struct
-  let work_manifest_url _config _account _work_manifest = None
+  let work_manifest_url _config _account _pull_number _work_manifest = None
+  let run_url _config _account _work_manifest_id = None
 end

--- a/code/src/terrat_vcs_gitlab_comment/terrat_vcs_gitlab_comment_ui.mli
+++ b/code/src/terrat_vcs_gitlab_comment/terrat_vcs_gitlab_comment_ui.mli
@@ -2,6 +2,10 @@ module Ui : sig
   val work_manifest_url :
     Terrat_vcs_api_gitlab.Config.t ->
     Terrat_vcs_api_gitlab.Account.t ->
+    int option ->
     ('a, Uuidm.t, 'b, 'c, 'd, 'e, 'f, 'g) Terrat_work_manifest3.t ->
     Uri.t option
+
+  val run_url :
+    Terrat_vcs_api_gitlab.Config.t -> Terrat_vcs_api_gitlab.Account.t -> Uuidm.t -> Uri.t option
 end

--- a/code/src/terrat_vcs_gitlab_comment_templates/tmpl/apply_complete2.tmpl
+++ b/code/src/terrat_vcs_gitlab_comment_templates/tmpl/apply_complete2.tmpl
@@ -126,7 +126,7 @@ No output shown due to comment size.
 {%- endif %}
 {%- for d in dirspaces %}
 
-## {{ d.dir }} | {{ d.workspace }} |  {% if d.success %}:white_check_mark:{% else %}:heavy_multiplication_x:{% endif %}
+## {% if d.run_url %}[{{ d.dir }} | {{ d.workspace }}]({{ d.run_url }}){% else %}{{ d.dir }} | {{ d.workspace }}{% endif %} |  {% if d.success %}:white_check_mark:{% else %}:heavy_multiplication_x:{% endif %}
   {%- if compact_dirspaces %}
 
 <details>

--- a/code/src/terrat_vcs_gitlab_comment_templates/tmpl/plan_complete2.tmpl
+++ b/code/src/terrat_vcs_gitlab_comment_templates/tmpl/plan_complete2.tmpl
@@ -188,7 +188,7 @@ No output shown due to comment size.
 {%- endif %}
 {%- for d in dirspaces %}
 
-## {{ d.dir }} | {{ d.workspace }} | {% if d.success %}{% if d.has_changes is defined and d.has_changes %}Success {% if compact_view %}:eyes:{% else %}:thumbsup:{% endif %}{% elif d.has_changes is defined and not d.has_changes %}No changes{% endif %}{% else %}:heavy_multiplication_x:{% endif %}
+## {% if d.run_url %}[{{ d.dir }} | {{ d.workspace }}]({{ d.run_url }}){% else %}{{ d.dir }} | {{ d.workspace }}{% endif %} | {% if d.success %}{% if d.has_changes is defined and d.has_changes %}Success {% if compact_view %}:eyes:{% else %}:thumbsup:{% endif %}{% elif d.has_changes is defined and not d.has_changes %}No changes{% endif %}{% else %}:heavy_multiplication_x:{% endif %}
   {%- if compact_dirspaces %}
 <details>
   <summary>Expand for details</summary>

--- a/code/src/terrat_vcs_provider2/terrat_vcs_provider2.ml
+++ b/code/src/terrat_vcs_provider2/terrat_vcs_provider2.ml
@@ -669,7 +669,11 @@ module type S = sig
 
   module Ui : sig
     val work_manifest_url :
-      Api.Config.t -> Api.Account.t -> ('a, 'b) Terrat_work_manifest3.Existing.t -> Uri.t option
+      Api.Config.t ->
+      Api.Account.t ->
+      int option ->
+      ('a, 'b) Terrat_work_manifest3.Existing.t ->
+      Uri.t option
   end
 
   module Job_context : sig


### PR DESCRIPTION
## Description

The "Outputs can be viewed in the Terrateam Console here" link in a plan/apply comment pointed at a single work manifest's run (`/runs/<work_manifest_id>`) — whichever directory finished last and re-posted the aggregated comment. For a PR that fans out into multiple runs (layered runs, differing environment/runs_on, tag-scoped applies), it now links to the PR-level runs page (`/runs/pr/<pull_number>`), which lists every run for the pull request. Each directory row in the comment also deep-links to its own run. Non-PR targets (drift) keep the single work-manifest URL. GitLab has no Console, so its links are unchanged.

Fixes #1359.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (explain):

## Checklist

- [ ] I have read the [contributing guidelines](https://github.com/terrateamio/terrateam/blob/main/CONTRIBUTING.md)
- [ ] The pull request title follows this format:
      `ISSUE_NUMBER ACTION_TYPE Short description` (e.g., `123 ADD Feature description`)
- [ ] I have added tests and documentation (if applicable)
- [ ] My changes generate no new warnings/errors and do not break existing functionality

## Additional context (optional)

The work manifest's `target` is erased to `unit` before the comment is built, so the fix threads the pull number (from `t.pull_request`) to the URL builder rather than matching on the target as the issue suggested. Per-directory deep links use each `el`'s `work_manifest_id`.