### PR TITLE
#1374 ADD notifications summary enabled default in ee

### DIFF
--- a/code/src/terrat_vcs_service_github_ee/terrat_vcs_service_github_ee.ml
+++ b/code/src/terrat_vcs_service_github_ee/terrat_vcs_service_github_ee.ml
@@ -439,8 +439,22 @@ module Provider :
           | None -> Abb.Future.return (Ok None))
       | None -> Abb.Future.return (Ok None)
 
+    let repo_config_system_defaults system_defaults =
+      let module V1 = Terrat_base_repo_config_v1 in
+      let system_defaults = CCOption.get_or ~default:V1.default system_defaults in
+      let view = V1.to_view system_defaults in
+      let { V1.View.notifications; _ } = view in
+      let notifications =
+        {
+          notifications with
+          V1.Notifications.summary = V1.Notifications.Summary.make ~enabled:true ();
+        }
+      in
+      V1.of_view { view with V1.View.notifications }
+
     let fetch_with_provenance ?system_defaults ?built_config request_id client repo ref_ =
       let open Abbs_future_combinators.Infix_result_monad in
+      let system_defaults = repo_config_system_defaults system_defaults in
       Abbs_future_combinators.Infix_result_app.(
         (fun remote_repo centralized_repo -> (remote_repo, centralized_repo))
         <$> Api.fetch_remote_repo ~request_id client repo
@@ -549,12 +563,10 @@ module Provider :
              (Jsonu.merge ~base:(get_json base) (get_json v)))
       in
       let system_defaults =
-        CCOption.map
-          (fun config ->
-            ( "system_defaults",
-              Terrat_repo_config.Version_1.to_yojson
-                (Terrat_base_repo_config_v1.to_version_1 config) ))
-          system_defaults
+        Some
+          ( "system_defaults",
+            Terrat_repo_config.Version_1.to_yojson
+              (Terrat_base_repo_config_v1.to_version_1 system_defaults) )
       in
       let built_config = CCOption.map (fun config -> ("config_builder", config)) built_config in
       match

--- a/code/src/terrat_vcs_service_gitlab_ee/terrat_vcs_service_gitlab_ee.ml
+++ b/code/src/terrat_vcs_service_gitlab_ee/terrat_vcs_service_gitlab_ee.ml
@@ -104,8 +104,22 @@ module Provider : module type of Terrat_vcs_service_gitlab_provider = struct
           | None -> Abb.Future.return (Ok None))
       | None -> Abb.Future.return (Ok None)
 
+    let repo_config_system_defaults system_defaults =
+      let module V1 = Terrat_base_repo_config_v1 in
+      let system_defaults = CCOption.get_or ~default:V1.default system_defaults in
+      let view = V1.to_view system_defaults in
+      let { V1.View.notifications; _ } = view in
+      let notifications =
+        {
+          notifications with
+          V1.Notifications.summary = V1.Notifications.Summary.make ~enabled:true ();
+        }
+      in
+      V1.of_view { view with V1.View.notifications }
+
     let fetch_with_provenance ?system_defaults ?built_config request_id client repo ref_ =
       let open Abbs_future_combinators.Infix_result_monad in
+      let system_defaults = repo_config_system_defaults system_defaults in
       Abbs_future_combinators.Infix_result_app.(
         (fun remote_repo centralized_repo -> (remote_repo, centralized_repo))
         <$> Api.fetch_remote_repo ~request_id client repo
@@ -214,12 +228,10 @@ module Provider : module type of Terrat_vcs_service_gitlab_provider = struct
              (Jsonu.merge ~base:(get_json base) (get_json v)))
       in
       let system_defaults =
-        CCOption.map
-          (fun config ->
-            ( "system_defaults",
-              Terrat_repo_config.Version_1.to_yojson
-                (Terrat_base_repo_config_v1.to_version_1 config) ))
-          system_defaults
+        Some
+          ( "system_defaults",
+            Terrat_repo_config.Version_1.to_yojson
+              (Terrat_base_repo_config_v1.to_version_1 system_defaults) )
       in
       let built_config = CCOption.map (fun config -> ("config_builder", config)) built_config in
       match

--- a/docs/src/content/docs/reference/configuration/notifications.mdx
+++ b/docs/src/content/docs/reference/configuration/notifications.mdx
@@ -12,7 +12,7 @@ notifications:
     - tag_query: ''
       comment_strategy: 'minimize'
   summary:
-    enabled: false
+    enabled: true
 ```
 
 ## Keys
@@ -35,14 +35,14 @@ The summary header is an [Enterprise](/editions) feature. Enabling it on the Ope
 
 | Key | Type | Description |
 | --- | --- | --- |
-| `enabled` | boolean | When `true`, each plan and apply comment starts with a summary header: a one-line rollup and a table of the dirspaces (directory and workspace combinations) executed in that comment, with their result and, for plans, whether there are changes. This lets reviewers see what a comment covers without expanding the full output. Default is `false`. |
+| `enabled` | boolean | When `true`, each plan and apply comment starts with a summary header: a one-line rollup and a table of the dirspaces (directory and workspace combinations) executed in that comment, with their result and, for plans, whether there are changes. This lets reviewers see what a comment covers without expanding the full output. Default is `true` in Enterprise Edition and `false` in Open Source Edition. |
 
-The summary header is rendered above the collapsed plan/apply output. Enable it (Enterprise only):
+The summary header is rendered above the collapsed plan/apply output. It is enabled by default in Enterprise Edition. To disable it:
 
 ```yaml
 notifications:
   summary:
-    enabled: true
+    enabled: false
 ```
 
 ## Examples


### PR DESCRIPTION
## Description

Enable notifications summary by default in EE

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (explain):

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/terrateamio/terrateam/blob/main/CONTRIBUTING.md)
- [x] The pull request title follows this format:
      `ISSUE_NUMBER ACTION_TYPE Short description` (e.g., `123 ADD Feature description`)
- [x] I have added tests and documentation (if applicable)
- [x] My changes generate no new warnings/errors and do not break existing functionality

## Additional context (optional)

<!-- Add any additional context here, e.g., screenshots, dependencies, etc. -->
