### PR TITLE
#1383 FIX Recognize stategraph/plan in comment publisher has_changes

### DIFF
--- a/code/src/terrat_vcs_github_comment/terrat_vcs_github_comment_publishers.ml
+++ b/code/src/terrat_vcs_github_comment/terrat_vcs_github_comment_publishers.ml
@@ -54,7 +54,7 @@ let steps_has_changes steps =
     CCList.find_map
       (function
         | {
-            O.step = "tf/plan" | "pulumi/plan" | "custom/plan" | "fly/plan";
+            O.step = "tf/plan" | "pulumi/plan" | "custom/plan" | "fly/plan" | "stategraph/plan";
             payload;
             success = _;
             _;

--- a/code/src/terrat_vcs_gitlab_comment/terrat_vcs_gitlab_comment_publishers.ml
+++ b/code/src/terrat_vcs_gitlab_comment/terrat_vcs_gitlab_comment_publishers.ml
@@ -54,7 +54,7 @@ let steps_has_changes steps =
     CCList.find_map
       (function
         | {
-            O.step = "tf/plan" | "pulumi/plan" | "custom/plan" | "fly/plan";
+            O.step = "tf/plan" | "pulumi/plan" | "custom/plan" | "fly/plan" | "stategraph/plan";
             payload;
             success = _;
             _;


### PR DESCRIPTION
## Description

Stategraph-engine plans always rendered as "no changes" in the MR/PR summary and dirspace header, even when the plan had changes.

The workflow plan step is named `engine.name + '/plan'`, so the Stategraph engine emits `stategraph/plan`. `steps_has_changes` in the GitLab and GitHub comment publishers only matched `"tf/plan" | "pulumi/plan" | "custom/plan" | "fly/plan"`, so `find_map` returned `None` and `has_changes` defaulted to `false` — even though the stored value is correct (`plans.has_changes = true`, `workflow_step_outputs` payload `has_changes = true`).

Adds `"stategraph/plan"` to the matched plan steps in both publishers. Fixes #1383.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (explain):

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/terrateamio/terrateam/blob/main/CONTRIBUTING.md)
- [x] The pull request title follows this format:
      `ISSUE_NUMBER ACTION_TYPE Short description` (e.g., `123 ADD Feature description`)
- [ ] I have added tests and documentation (if applicable)
- [x] My changes generate no new warnings/errors and do not break existing functionality

## Additional context (optional)

Companion runner-side fix: terrateamio/action#616. The plan output body already renders via the run fallback, so the `output_of_plan` match is intentionally left unchanged to keep this minimal.
