### PR TITLE
1385 FIX Support config_builder in centralized config

### DIFF
--- a/code/src/terrat_vcs_event_evaluator/dune
+++ b/code/src/terrat_vcs_event_evaluator/dune
@@ -6,6 +6,7 @@
   logs
   ouuid
   prmths
+  sha
   sln
   str_template
   terrat_base_repo_config_v1

--- a/code/src/terrat_vcs_event_evaluator/terrat_vcs_event_evaluator.ml
+++ b/code/src/terrat_vcs_event_evaluator/terrat_vcs_event_evaluator.ml
@@ -1731,15 +1731,46 @@ module Make (S : Terrat_vcs_provider2.S) = struct
           >>= fun remote_repo ->
           Abb.Future.return (Ok (S.Api.Remote_repo.default_branch remote_repo))
 
-    let query_built_config ctx state =
+    let build_config_cache_ref ref_ repo_config =
+      let json_str =
+        repo_config
+        |> Terrat_base_repo_config_v1.to_version_1
+        |> Terrat_repo_config.Version_1.to_yojson
+        |> Yojson.Safe.sort
+        |> Yojson.Safe.to_string
+      in
+      let sha256_hex = Sha256.(to_hex (string json_str)) in
+      S.Api.Ref.of_string (S.Api.Ref.to_string ref_ ^ ":" ^ sha256_hex)
+
+    let repo_config_build_cache_ref ctx state =
       let open Abbs_future_combinators.Infix_result_monad in
+      client ctx state
+      >>= fun client ->
+      branch_ref ctx state
+      >>= fun branch_ref' ->
       working_branch_ref ctx state
       >>= fun working_branch_ref' ->
+      repo_config_system_defaults ctx state
+      >>= fun system_defaults ->
+      Repo_config.fetch_with_provenance
+        ~system_defaults
+        state.State.request_id
+        (Ctx.config ctx)
+        client
+        (Event.repo state.State.event)
+        branch_ref'
+      >>= fun (_, repo_config) ->
+      Abb.Future.return (Ok (build_config_cache_ref working_branch_ref' repo_config))
+
+    let query_built_config ctx state =
+      let open Abbs_future_combinators.Infix_result_monad in
+      repo_config_build_cache_ref ctx state
+      >>= fun build_cache_ref ->
       query_repo_config_json
         state.State.request_id
         (Ctx.storage ctx)
         (Event.account state.State.event)
-        working_branch_ref'
+        build_cache_ref
 
     let query_built_tree ctx state =
       let open Abbs_future_combinators.Infix_result_monad in
@@ -6824,13 +6855,13 @@ module Make (S : Terrat_vcs_provider2.S) = struct
               | Ok _ ->
                   let open Abbs_future_combinators.Infix_result_monad in
                   let account = Event.account state.State.event in
-                  Dv.working_branch_ref ctx state
-                  >>= fun working_branch_ref' ->
+                  Dv.repo_config_build_cache_ref ctx state
+                  >>= fun build_cache_ref ->
                   store_repo_config_json
                     state.State.request_id
                     (Ctx.storage ctx)
                     account
-                    working_branch_ref'
+                    build_cache_ref
                     config
                   >>= fun () ->
                   H.run_interactive ctx state (fun () ->

--- a/code/src/terrat_vcs_event_evaluator2/terrat_vcs_event_evaluator2_tasks.ml
+++ b/code/src/terrat_vcs_event_evaluator2/terrat_vcs_event_evaluator2_tasks.ml
@@ -28,6 +28,28 @@ struct
   let time_it s l f =
     Abbs_time_it.run (fun time -> Logs.info (fun m -> l m (Builder.log_id s) time)) f
 
+  let repo_config_hash repo_config =
+    let json_str =
+      repo_config
+      |> Terrat_base_repo_config_v1.to_version_1
+      |> Terrat_repo_config.Version_1.to_yojson
+      |> Yojson.Safe.sort
+      |> Yojson.Safe.to_string
+    in
+    Sha256.(to_hex (string json_str))
+
+  let build_config_cache_ref ref_ repo_config =
+    S.Api.Ref.of_string (S.Api.Ref.to_string ref_ ^ ":" ^ repo_config_hash repo_config)
+
+  let repo_config_cache_key account repo ref_ repo_config =
+    S.Api.Account.to_string account
+    ^ "."
+    ^ S.Api.Repo.to_string repo
+    ^ "."
+    ^ S.Api.Ref.to_string ref_
+    ^ ":"
+    ^ repo_config_hash repo_config
+
   let update_job_state_completed s job_id db =
     time_it
       s
@@ -835,9 +857,13 @@ struct
           >>= fun dest_branch_ref ->
           fetch Keys.working_branch_ref
           >>= fun branch_ref ->
+          fetch Keys.repo_config_raw'
+          >>= fun (_, repo_config_raw) ->
+          let cache_ref = build_config_cache_ref branch_ref repo_config_raw in
           fetch Keys.working_branch_name
           >>= fun branch ->
           Build_config_wm.run
+            ~cache_ref
             ~dest_branch_ref
             ~branch_ref
             ~branch
@@ -1059,9 +1085,13 @@ struct
           >>= fun _ ->
           fetch Keys.dest_branch_ref
           >>= fun dest_branch_ref ->
+          fetch Keys.repo_config_dest_branch_raw'
+          >>= fun (_, repo_config_raw) ->
+          let cache_ref = build_config_cache_ref dest_branch_ref repo_config_raw in
           fetch Keys.dest_branch_name
           >>= fun branch ->
           Build_config_wm.run
+            ~cache_ref
             ~dest_branch_ref
             ~branch_ref:dest_branch_ref
             ~branch
@@ -1081,6 +1111,7 @@ struct
           >>= fun (_, repo_config_raw) ->
           let config_builder = V1.config_builder repo_config_raw in
           if config_builder.V1.Config_builder.enabled then
+            let cache_ref = build_config_cache_ref dest_branch_ref repo_config_raw in
             fetch Keys.built_repo_config_dest_branch_wm_completed
             >>= fun _ ->
             Builder.run_db s ~f:(fun db ->
@@ -1094,11 +1125,7 @@ struct
                       (S.Api.Ref.to_string dest_branch_ref)
                       time)
                   (fun () ->
-                    S.Db.query_repo_config_json
-                      ~request_id:(Builder.log_id s)
-                      db
-                      account
-                      dest_branch_ref))
+                    S.Db.query_repo_config_json ~request_id:(Builder.log_id s) db account cache_ref))
           else Abb.Future.return (Ok None))
 
     let repo_tree_dest_branch =
@@ -1179,6 +1206,7 @@ struct
           >>= fun (_, repo_config_raw) ->
           let config_builder = V1.config_builder repo_config_raw in
           if config_builder.V1.Config_builder.enabled then
+            let cache_ref = build_config_cache_ref branch_ref repo_config_raw in
             fetch Keys.built_repo_config_branch_wm_completed
             >>= fun _ ->
             Builder.run_db s ~f:(fun db ->
@@ -1192,7 +1220,7 @@ struct
                       (S.Api.Ref.to_string branch_ref)
                       time)
                   (fun () ->
-                    S.Db.query_repo_config_json ~request_id:(Builder.log_id s) db account branch_ref))
+                    S.Db.query_repo_config_json ~request_id:(Builder.log_id s) db account cache_ref))
           else Abb.Future.return (Ok None))
 
     let repo_config_system_defaults =
@@ -1280,11 +1308,7 @@ struct
           >>= fun branch_ref ->
           let cache_key =
             ( "cache2.derived_repo_config_empty_index",
-              S.Api.Account.to_string account
-              ^ "."
-              ^ S.Api.Repo.to_string repo
-              ^ "."
-              ^ S.Api.Ref.to_string branch_ref )
+              repo_config_cache_key account repo branch_ref repo_config_raw )
           in
           Cache.derived_repo_config
             ~cache_key
@@ -1318,11 +1342,7 @@ struct
           >>= fun branch_ref ->
           let cache_key =
             ( "cache2.derived_repo_config",
-              S.Api.Account.to_string account
-              ^ "."
-              ^ S.Api.Repo.to_string repo
-              ^ "."
-              ^ S.Api.Ref.to_string branch_ref )
+              repo_config_cache_key account repo branch_ref repo_config_raw )
           in
           Cache.derived_repo_config
             ~cache_key
@@ -1454,11 +1474,7 @@ struct
           >>= fun dest_branch_ref ->
           let cache_key =
             ( "cache2.repo_config_empty_index",
-              S.Api.Account.to_string account
-              ^ "."
-              ^ S.Api.Repo.to_string repo
-              ^ "."
-              ^ S.Api.Ref.to_string dest_branch_ref )
+              repo_config_cache_key account repo dest_branch_ref repo_config_raw )
           in
           Cache.derived_repo_config
             ~cache_key
@@ -1492,11 +1508,7 @@ struct
           >>= fun dest_branch_ref ->
           let cache_key =
             ( "cache2.repo_config_empty_index",
-              S.Api.Account.to_string account
-              ^ "."
-              ^ S.Api.Repo.to_string repo
-              ^ "."
-              ^ S.Api.Ref.to_string dest_branch_ref )
+              repo_config_cache_key account repo dest_branch_ref repo_config_raw )
           in
           Cache.derived_repo_config
             ~cache_key

--- a/code/src/terrat_vcs_event_evaluator2/terrat_vcs_event_evaluator2_wm_sm_build_config.ml
+++ b/code/src/terrat_vcs_event_evaluator2/terrat_vcs_event_evaluator2_wm_sm_build_config.ml
@@ -71,11 +71,11 @@ struct
     let branch_name = S.Api.Ref.to_string branch_name in
     if branch = branch_name then "terrateam build-config" else "terrateam build-config " ^ branch
 
-  let create ~dest_branch_ref ~branch_ref ~branch s { Bs.Fetcher.fetch } =
+  let create ~cache_ref ~dest_branch_ref ~branch_ref ~branch s { Bs.Fetcher.fetch } =
     let open Irm in
     fetch Keys.account
     >>= fun account ->
-    Builder.run_db s ~f:(fun db -> query_repo_config_json s db account branch_ref)
+    Builder.run_db s ~f:(fun db -> query_repo_config_json s db account cache_ref)
     >>= function
     | None ->
         fetch Keys.repo
@@ -248,7 +248,7 @@ struct
     fetch Keys.publish_comment
     >>= fun publish_comment -> publish_comment' publish_comment Msg.Unexpected_temporary_err
 
-  let result ~branch_ref ~branch work_manifest result s { Bs.Fetcher.fetch } =
+  let result ~cache_ref ~branch_ref ~branch work_manifest result s { Bs.Fetcher.fetch } =
     let open Irm in
     let fail msg =
       fetch Keys.account
@@ -286,7 +286,7 @@ struct
             let open Irm in
             fetch Keys.account
             >>= fun account ->
-            Builder.run_db s ~f:(fun db -> store_repo_config_json s db account branch_ref config)
+            Builder.run_db s ~f:(fun db -> store_repo_config_json s db account cache_ref config)
             >>= fun () ->
             fetch Keys.repo
             >>= fun repo ->
@@ -321,15 +321,15 @@ struct
         assert false
     | Terrat_api_components_work_manifest_result.Work_manifest_index_result _ -> assert false
 
-  let run ~dest_branch_ref ~branch_ref ~branch ~name =
+  let run ~cache_ref ~dest_branch_ref ~branch_ref ~branch ~name =
     Wm_sm.run
       ~name
       ~eq:(eq dest_branch_ref branch_ref)
       ~dest_branch_ref
       ~branch_ref
       ~branch
-      ~create
+      ~create:(create ~cache_ref)
       ~initiate:(initiate ~branch)
       ~fail:(fail ~branch)
-      ~result:(result ~branch_ref ~branch)
+      ~result:(result ~cache_ref ~branch_ref ~branch)
 end

--- a/code/src/terrat_vcs_event_evaluator2/terrat_vcs_event_evaluator2_wm_sm_build_config.mli
+++ b/code/src/terrat_vcs_event_evaluator2/terrat_vcs_event_evaluator2_wm_sm_build_config.mli
@@ -5,6 +5,7 @@ module Make
   module Wm_sm : module type of Terrat_vcs_event_evaluator2_wm_sm.Make (S) (Keys)
 
   val run :
+    cache_ref:S.Api.Ref.t ->
     dest_branch_ref:S.Api.Ref.t ->
     branch_ref:S.Api.Ref.t ->
     branch:S.Api.Ref.t ->

--- a/code/src/terrat_vcs_service_github_ee/terrat_vcs_service_github_ee.ml
+++ b/code/src/terrat_vcs_service_github_ee/terrat_vcs_service_github_ee.ml
@@ -623,13 +623,16 @@ module Provider :
                    repo_config ))
       | _, _, (Some (_, _) as forced_repo_config), _, _ ->
           let provenance =
-            collect_provenance [ system_defaults; global_defaults; forced_repo_config ]
+            collect_provenance
+              [ system_defaults; global_defaults; built_config; forced_repo_config ]
           in
-          validate_configs [ system_defaults; global_defaults; forced_repo_config ]
+          validate_configs [ system_defaults; global_defaults; built_config; forced_repo_config ]
           >>= fun () ->
           Abb.Future.return (merge ~base:system_defaults global_defaults)
           >>= fun global_defaults ->
-          Abb.Future.return (merge ~base:global_defaults forced_repo_config)
+          Abb.Future.return (merge ~base:global_defaults built_config)
+          >>= fun repo_config ->
+          Abb.Future.return (merge ~base:repo_config forced_repo_config)
           >>= fun repo_config ->
           wrap_err
             "repo"

--- a/code/src/terrat_vcs_service_gitlab_ee/terrat_vcs_service_gitlab_ee.ml
+++ b/code/src/terrat_vcs_service_gitlab_ee/terrat_vcs_service_gitlab_ee.ml
@@ -288,13 +288,16 @@ module Provider : module type of Terrat_vcs_service_gitlab_provider = struct
                    repo_config ))
       | _, _, (Some (_, _) as forced_repo_config), _, _ ->
           let provenance =
-            collect_provenance [ system_defaults; global_defaults; forced_repo_config ]
+            collect_provenance
+              [ system_defaults; global_defaults; built_config; forced_repo_config ]
           in
-          validate_configs [ system_defaults; global_defaults; forced_repo_config ]
+          validate_configs [ system_defaults; global_defaults; built_config; forced_repo_config ]
           >>= fun () ->
           Abb.Future.return (merge ~base:system_defaults global_defaults)
           >>= fun global_defaults ->
-          Abb.Future.return (merge ~base:global_defaults forced_repo_config)
+          Abb.Future.return (merge ~base:global_defaults built_config)
+          >>= fun repo_config ->
+          Abb.Future.return (merge ~base:repo_config forced_repo_config)
           >>= fun repo_config ->
           wrap_err
             "repo"


### PR DESCRIPTION
## Description

Fixes #1385.

Adds support for `config_builder` from centralized `config/overrides.yml` so org-wide config can keep the builder script in one place instead of copying it into each target repo.

The bug had two cache/merge causes:

- Build-config output was keyed only by the target repository SHA, so centralized config changes could be missed when the target repo did not change.
- Derived repo-config output was also keyed only by target ref, so `terrateam repo-config` could render stale config even after the centralized builder output was stored.

This updates build-config and derived repo-config cache keys to include the merged repository config hash, and includes `built_config` in centralized forced-config merging for GitHub EE and GitLab EE while keeping forced config authoritative.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (explain):

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/terrateamio/terrateam/blob/main/CONTRIBUTING.md)
- [x] The pull request title follows this format:
      `ISSUE_NUMBER ACTION_TYPE Short description` (e.g., `123 ADD Feature description`)
- [x] I have added tests and documentation (if applicable)
- [x] My changes generate no new warnings/errors and do not break existing functionality

## Additional context (optional)

Validation:

- `git diff --check`
- Dockerized `dune build @fmt`
- Dockerized `dune build code/src/terrat_vcs_event_evaluator2/terrat_vcs_event_evaluator2.cmxa`
- CI run `29785025130`: all GitHub Actions jobs succeeded.
- CI run `29785025130`: `build-test (terrat-ee, amd64)` published `ghcr.io/terrateamio/terrat-ee-dev:20260720-1385-support-config-builder-centralized-forced-config-f882f74-amd64`.
- Docker Compose end-to-end test with that image: triggered `terrateam repo-config` on `joshpollara/kick-the-tires#28` while centralized config lived in `joshpollara/terrateam:b5dddff822fd7e4702a16471a10d8f85426178e8:config/overrides.yml`.
- Bot response `5028033250` included sources `joshpollara/terrateam:...:config/overrides.yml` and `config_builder`, and the rendered YAML included the centralized builder output `parallel_runs: 7`.
