### PR TITLE
#1388 FIX Distinguish an empty built repo tree from one never built

### DIFF
--- a/code/src/terrat/migrations/2026-07-21-add-repo-tree-builds.sql
+++ b/code/src/terrat/migrations/2026-07-21-add-repo-tree-builds.sql
@@ -1,0 +1,18 @@
+-- Records that a repo tree was successfully built for a commit.
+--
+-- The rows in [repo_trees] cannot distinguish "the tree was built and it is
+-- empty" from "the tree was never built", because an empty tree stores zero
+-- rows.  A tree builder that legitimately outputs no files was therefore
+-- treated as a missing tree and failed the evaluation.  This table records the
+-- build itself so the two cases can be told apart.
+create table repo_tree_builds (
+    sha text not null,
+    installation uuid not null,
+    created_at timestamp with time zone not null default (now()),
+    primary key (installation, sha)
+);
+
+-- Backfill the trees we already have so existing commits are not rebuilt.
+insert into repo_tree_builds (installation, sha)
+select distinct installation, sha from repo_trees
+on conflict do nothing;

--- a/code/src/terrat/terrat_migrations.ml
+++ b/code/src/terrat/terrat_migrations.ml
@@ -280,6 +280,7 @@ let migrations =
     ( "extend-repo-configs-with-history",
       run_sql [%blob "migrations/2026-07-05-extend-repo-configs-with-history.sql"] );
     ("add-tasks-user-id", run_sql [%blob "migrations/2026-07-23-add-tasks-user-id.sql"]);
+    ("add-repo-tree-builds", run_sql [%blob "migrations/2026-07-21-add-repo-tree-builds.sql"]);
   ]
 
 let run config storage = Mig.run { Migrate.config; storage; tx = () } migrations

--- a/code/src/terrat_vcs_service_github/sql/insert_repo_tree_build.sql
+++ b/code/src/terrat_vcs_service_github/sql/insert_repo_tree_build.sql
@@ -1,0 +1,8 @@
+insert into repo_tree_builds (sha, installation)
+select
+        $sha,
+        gim.core_id
+from github_installations_map as gim
+where gim.installation_id = $installation_id
+on conflict on constraint repo_tree_builds_pkey
+do nothing

--- a/code/src/terrat_vcs_service_github/sql/select_repo_tree_build.sql
+++ b/code/src/terrat_vcs_service_github/sql/select_repo_tree_build.sql
@@ -1,0 +1,5 @@
+select rtb.sha
+from repo_tree_builds as rtb
+inner join github_installations_map as gim
+      on gim.core_id = rtb.installation
+where gim.installation_id = $installation_id and rtb.sha = $sha

--- a/code/src/terrat_vcs_service_github/terrat_vcs_service_github_provider.ml
+++ b/code/src/terrat_vcs_service_github/terrat_vcs_service_github_provider.ml
@@ -357,6 +357,13 @@ module Db = struct
         /% Var.(array (option (boolean "changed")))
         /% Var.(str_array (option (text "id"))))
 
+    let insert_repo_tree_build =
+      Pgsql_io.Typed_sql.(
+        sql
+        /^ read [%blob "sql/insert_repo_tree_build.sql"]
+        /% Var.bigint "installation_id"
+        /% Var.text "sha")
+
     let upsert_flow_state_query = read [%blob "sql/update_flow_state.sql"]
 
     let upsert_flow_state () =
@@ -454,6 +461,16 @@ module Db = struct
         /% Var.bigint "installation_id"
         /% Var.text "sha"
         /% Var.(option (text "base_sha")))
+
+    let select_repo_tree_build =
+      Pgsql_io.Typed_sql.(
+        sql
+        //
+        (* sha *)
+        Ret.text
+        /^ read [%blob "sql/select_repo_tree_build.sql"]
+        /% Var.bigint "installation_id"
+        /% Var.text "sha")
 
     let select_next_work_manifest =
       Pgsql_io.Typed_sql.(
@@ -1267,7 +1284,22 @@ module Db = struct
               (CCList.map (fun { I.id; _ } -> id) chunk)))
       (CCList.chunks not_a_bad_chunk_size files)
     >>= function
-    | Ok () -> Abb.Future.return (Ok ())
+    | Ok () -> (
+        (* Record the build itself.  An empty tree stores no rows, so this is
+           the only way to tell a built-but-empty tree apart from one that was
+           never built. *)
+        Metrics.Psql_query_time.time (Metrics.psql_query_time "insert_repo_tree_build") (fun () ->
+            Pgsql_io.Prepared_stmt.execute
+              db
+              Sql.insert_repo_tree_build
+              (CCInt64.of_int @@ Api.Account.id account)
+              (Api.Ref.to_string ref_))
+        >>= function
+        | Ok () -> Abb.Future.return (Ok ())
+        | Error (#Pgsql_io.err as err) ->
+            Prmths.Counter.inc_one Metrics.pgsql_errors_total;
+            Logs.err (fun m -> m "%s : ERROR : %a" request_id Pgsql_io.pp_err err);
+            Abb.Future.return (Error `Error))
     | Error (#Pgsql_io.err as err) ->
         Prmths.Counter.inc_one Metrics.pgsql_errors_total;
         Logs.err (fun m -> m "%s : ERROR : %a" request_id Pgsql_io.pp_err err);
@@ -1651,7 +1683,23 @@ module Db = struct
           (Api.Ref.to_string ref_)
           (CCOption.map Api.Ref.to_string base_ref))
     >>= function
-    | Ok [] -> Abb.Future.return (Ok None)
+    | Ok [] -> (
+        (* No rows is ambiguous: either the tree was built and is empty, or it
+           was never built.  [repo_tree_builds] tells the two apart. *)
+        Metrics.Psql_query_time.time (Metrics.psql_query_time "select_repo_tree_build") (fun () ->
+            Pgsql_io.Prepared_stmt.fetch
+              db
+              Sql.select_repo_tree_build
+              ~f:CCFun.id
+              (CCInt64.of_int @@ Api.Account.id account)
+              (Api.Ref.to_string ref_))
+        >>= function
+        | Ok (_ :: _) -> Abb.Future.return (Ok (Some []))
+        | Ok [] -> Abb.Future.return (Ok None)
+        | Error (#Pgsql_io.err as err) ->
+            Prmths.Counter.inc_one Metrics.pgsql_errors_total;
+            Logs.err (fun m -> m "%s : ERROR : %a" request_id Pgsql_io.pp_err err);
+            Abb.Future.return (Error `Error))
     | Ok files -> Abb.Future.return (Ok (Some files))
     | Error (#Pgsql_io.err as err) ->
         Prmths.Counter.inc_one Metrics.pgsql_errors_total;

--- a/code/src/terrat_vcs_service_gitlab/sql/insert_repo_tree_build.sql
+++ b/code/src/terrat_vcs_service_gitlab/sql/insert_repo_tree_build.sql
@@ -1,0 +1,8 @@
+insert into repo_tree_builds (sha, installation)
+select
+        $sha,
+        gim.core_id
+from gitlab_installations_map as gim
+where gim.installation_id = $installation_id
+on conflict on constraint repo_tree_builds_pkey
+do nothing

--- a/code/src/terrat_vcs_service_gitlab/sql/select_repo_tree_build.sql
+++ b/code/src/terrat_vcs_service_gitlab/sql/select_repo_tree_build.sql
@@ -1,0 +1,5 @@
+select rtb.sha
+from repo_tree_builds as rtb
+inner join gitlab_installations_map as gim
+      on gim.core_id = rtb.installation
+where gim.installation_id = $installation_id and rtb.sha = $sha

--- a/code/src/terrat_vcs_service_gitlab/terrat_vcs_service_gitlab_provider.ml
+++ b/code/src/terrat_vcs_service_gitlab/terrat_vcs_service_gitlab_provider.ml
@@ -357,6 +357,13 @@ module Db = struct
         /% Var.(array (option (boolean "changed")))
         /% Var.(str_array (option (text "id"))))
 
+    let insert_repo_tree_build =
+      Pgsql_io.Typed_sql.(
+        sql
+        /^ read [%blob "sql/insert_repo_tree_build.sql"]
+        /% Var.bigint "installation_id"
+        /% Var.text "sha")
+
     let upsert_flow_state_query = read [%blob "sql/update_flow_state.sql"]
 
     let upsert_flow_state () =
@@ -454,6 +461,16 @@ module Db = struct
         /% Var.bigint "installation_id"
         /% Var.text "sha"
         /% Var.(option (text "base_sha")))
+
+    let select_repo_tree_build =
+      Pgsql_io.Typed_sql.(
+        sql
+        //
+        (* sha *)
+        Ret.text
+        /^ read [%blob "sql/select_repo_tree_build.sql"]
+        /% Var.bigint "installation_id"
+        /% Var.text "sha")
 
     let select_next_work_manifest =
       Pgsql_io.Typed_sql.(
@@ -1266,7 +1283,22 @@ module Db = struct
               (CCList.map (fun { I.id; _ } -> id) chunk)))
       (CCList.chunks not_a_bad_chunk_size files)
     >>= function
-    | Ok () -> Abb.Future.return (Ok ())
+    | Ok () -> (
+        (* Record the build itself.  An empty tree stores no rows, so this is
+           the only way to tell a built-but-empty tree apart from one that was
+           never built. *)
+        Metrics.Psql_query_time.time (Metrics.psql_query_time "insert_repo_tree_build") (fun () ->
+            Pgsql_io.Prepared_stmt.execute
+              db
+              Sql.insert_repo_tree_build
+              (CCInt64.of_int @@ Api.Account.id account)
+              (Api.Ref.to_string ref_))
+        >>= function
+        | Ok () -> Abb.Future.return (Ok ())
+        | Error (#Pgsql_io.err as err) ->
+            Prmths.Counter.inc_one Metrics.pgsql_errors_total;
+            Logs.err (fun m -> m "%s : ERROR : %a" request_id Pgsql_io.pp_err err);
+            Abb.Future.return (Error `Error))
     | Error (#Pgsql_io.err as err) ->
         Prmths.Counter.inc_one Metrics.pgsql_errors_total;
         Logs.err (fun m -> m "%s : ERROR : %a" request_id Pgsql_io.pp_err err);
@@ -1607,7 +1639,23 @@ module Db = struct
           (Api.Ref.to_string ref_)
           (CCOption.map Api.Ref.to_string base_ref))
     >>= function
-    | Ok [] -> Abb.Future.return (Ok None)
+    | Ok [] -> (
+        (* No rows is ambiguous: either the tree was built and is empty, or it
+           was never built.  [repo_tree_builds] tells the two apart. *)
+        Metrics.Psql_query_time.time (Metrics.psql_query_time "select_repo_tree_build") (fun () ->
+            Pgsql_io.Prepared_stmt.fetch
+              db
+              Sql.select_repo_tree_build
+              ~f:CCFun.id
+              (CCInt64.of_int @@ Api.Account.id account)
+              (Api.Ref.to_string ref_))
+        >>= function
+        | Ok (_ :: _) -> Abb.Future.return (Ok (Some []))
+        | Ok [] -> Abb.Future.return (Ok None)
+        | Error (#Pgsql_io.err as err) ->
+            Prmths.Counter.inc_one Metrics.pgsql_errors_total;
+            Logs.err (fun m -> m "%s : ERROR : %a" request_id Pgsql_io.pp_err err);
+            Abb.Future.return (Error `Error))
     | Ok files -> Abb.Future.return (Ok (Some files))
     | Error (#Pgsql_io.err as err) ->
         Prmths.Counter.inc_one Metrics.pgsql_errors_total;

--- a/docs/src/content/docs/reference/configuration/tree-builder.mdx
+++ b/docs/src/content/docs/reference/configuration/tree-builder.mdx
@@ -29,30 +29,33 @@ When `tree_builder` is enabled, Terrateam executes your custom script during the
 
 ### Output
 
-The script must output valid JSON to stdout with the following structure
+The script must output a JSON array of file objects to stdout
 
 ```json
-{
-  "files": [
-    {
-      "path": "path/to/file1.tf",
-      "id": "abc123def456"
-    },
-    {
-      "path": "path/to/file2.tf",
-      "id": "789ghi012jkl"
-    }
-  ]
-}
+[
+  {
+    "path": "path/to/file1.tf",
+    "id": "abc123def456"
+  },
+  {
+    "path": "path/to/file2.tf",
+    "id": "789ghi012jkl"
+  }
+]
 ```
+
+The output is a bare array, not an object wrapping a `files` key. A script that
+outputs `{"files": [...]}` fails with `TypeError: string indices must be
+integers`.
+
+An empty array is valid and means the repository has no files to track.
 
 ### Output Fields
 
 | Field | Type | Required | Description |
 | --- | --- | --- | --- |
-| files | Array | Yes | Array of file objects |
-| files[].path | String | Yes | Relative path from repository root |
-| files[].id | String | Yes | Unique identifier for the file (typically a hash). Terrateam compares IDs between branches to detect changes |
+| [].path | String | Yes | Relative path from repository root |
+| [].id | String | No | Unique identifier for the file (typically a hash). Terrateam compares IDs between branches to detect changes |
 
 ## How It Works
 


### PR DESCRIPTION
## Description

Fixes #1388

An empty tree stores zero rows in `repo_trees`, which was indistinguishable from a tree that was never built, so a `tree_builder` that legitimately returns no files failed with `EXPECTED_BUILT_REPO_TREE`.

Successful builds are now recorded in a new `repo_tree_builds` table, so `query_repo_tree` returns `Some []` for a built-but-empty tree and `None` only when no build happened. A failed build records nothing and still errors as before.

This keeps `query_repo_tree`'s signature, so there are no call-site changes. It also stops build-tree from re-running on every event for an empty tree, since `wm_sm_repo_tree.create` now sees `Some []`.

Also corrects the `tree_builder` reference docs, which documented the runner-to-server API payload (`{"files": [...]}`) rather than the script's own output contract, and contradicted the setup guide, which had the bare array correct.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Other (explain):

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/terrateamio/terrateam/blob/main/CONTRIBUTING.md)
- [x] The pull request title follows this format:
      `ISSUE_NUMBER ACTION_TYPE Short description` (e.g., `123 ADD Feature description`)
- [x] I have added tests and documentation (if applicable) — docs updated; no automated test, see below
- [x] My changes generate no new warnings/errors and do not break existing functionality

## Additional context (optional)

No automated test was added. The DB layer has no test harness to extend — `code/tests/terrat_vcs_event_evaluator2` does not exercise providers or Postgres — so covering this would mean standing up a database-backed test fixture.

Verified manually instead, against a dev image on a local compose stack with a `tree_builder` script:

| Case | Marker | Rows | Behavior |
| --- | --- | --- | --- |
| Built, empty (`echo '[]'`) | written | 0 | proceeds to build-config |
| Build failed (malformed output) | none | 0 | still errors |

Before the change the first case logged `EXPECTED_BUILT_REPO_TREE` and published `UNEXPECTED_TEMPORARY_ERR`. The second case is the regression guard: a failed tree build must not be mistaken for an empty one.

The migration backfills `repo_tree_builds` from existing `repo_trees` rows so cached trees are not rebuilt on upgrade.
