### PR TITLE
#1214 ADD unified pull request summary comment

### DIFF
--- a/api_schemas/terrat/config-schema.json
+++ b/api_schemas/terrat/config-schema.json
@@ -1235,6 +1235,14 @@
         "enabled": {
           "default": false,
           "type": "boolean"
+        },
+        "mode": {
+          "default": "header",
+          "enum": [
+            "header",
+            "pull_request"
+          ],
+          "type": "string"
         }
       },
       "type": "object"

--- a/code/src/abb_curl/abb_curl.ml
+++ b/code/src/abb_curl/abb_curl.ml
@@ -613,6 +613,12 @@ module Make (Abb : Abb_intf.S with type Native.t = Unix.file_descr) = struct
             Curl.set_customrequest handle "DELETE";
             maybe_set_body_writer handle body
         | `PATCH body ->
+            (* curl only consumes the body read-callback in POST/upload mode; a
+               custom request verb on its own sends the Content-Length from
+               set_postfieldsize with no bytes behind it, which servers reject
+               as an empty body.  Enable POST send-mode when there is a body and
+               let CUSTOMREQUEST override the verb back to PATCH. *)
+            if body <> None then Curl.set_post handle true;
             Curl.set_customrequest handle "PATCH";
             maybe_set_body_writer handle body
         | `Custom (meth_, body) ->

--- a/code/src/terrat/migrations/2026-07-21-add-unified-comment-tracking.sql
+++ b/code/src/terrat/migrations/2026-07-21-add-unified-comment-tracking.sql
@@ -1,0 +1,16 @@
+create table if not exists github_unified_comments(
+    -- the id github gave us, null until the first unified comment is posted
+    comment_id bigint,
+    repository bigint not null,
+    pull_number bigint not null,
+    dirty bigint not null default 0,
+    created_at timestamptz not null default current_timestamp,
+    foreign key (repository, pull_number) references github_pull_requests (repository, pull_number),
+    primary key (repository, pull_number)
+);
+
+-- Supports looking up a dirspace's step outputs without scanning every row of
+-- a work manifest.
+create index if not exists workflow_step_outputs_dirspace_idx
+    on workflow_step_outputs (work_manifest, (scope->>'dir'), (scope->>'workspace'))
+    where scope->>'type' = 'dirspace';

--- a/code/src/terrat/terrat_migrations.ml
+++ b/code/src/terrat/terrat_migrations.ml
@@ -279,6 +279,8 @@ let migrations =
       run_sql [%blob "migrations/2026-03-19-delete-repo-tree-cache.sql"] );
     ( "extend-repo-configs-with-history",
       run_sql [%blob "migrations/2026-07-05-extend-repo-configs-with-history.sql"] );
+    ( "add-unified-comment-tracking",
+      run_sql [%blob "migrations/2026-07-21-add-unified-comment-tracking.sql"] );
   ]
 
 let run config storage = Mig.run { Migrate.config; storage; tx = () } migrations

--- a/code/src/terrat_base_repo_config_v1/terrat_base_repo_config_v1.ml
+++ b/code/src/terrat_base_repo_config_v1/terrat_base_repo_config_v1.ml
@@ -1055,10 +1055,25 @@ module Notifications = struct
   end
 
   module Summary = struct
-    (* Enterprise feature: the comment summary header only renders in the
-       Enterprise Edition.  Defaults to disabled so Open Source users are not
-       blocked by the premium-feature gate on the default configuration. *)
-    type t = { enabled : bool [@default false] } [@@deriving make, show, yojson, eq]
+    module Mode = struct
+      type t =
+        | Header
+        | Pull_request
+      [@@deriving show, yojson, eq]
+    end
+
+    (* Enterprise feature: the comment summary only renders in the Enterprise
+       Edition.  Defaults to disabled so Open Source users are not blocked by
+       the premium-feature gate on the default configuration.
+
+       [Header] renders the summary as a header inside each plan/apply comment.
+       [Pull_request] maintains a single unified summary comment for the whole
+       pull request and suppresses the per-work-manifest result comments. *)
+    type t = {
+      enabled : bool; [@default false]
+      mode : Mode.t; [@default Mode.Header]
+    }
+    [@@deriving make, show, yojson, eq]
   end
 
   type t = {
@@ -2469,7 +2484,13 @@ let of_version_1_notifications notifications =
   let policies = CCOption.get_or ~default:[] policies in
   let summary =
     match summary with
-    | Some { Sn.enabled } -> { Notifications.Summary.enabled }
+    | Some { Sn.enabled; mode } ->
+        let mode =
+          match mode with
+          | `Header -> Notifications.Summary.Mode.Header
+          | `Pull_request -> Notifications.Summary.Mode.Pull_request
+        in
+        { Notifications.Summary.enabled; mode }
     | None -> Notifications.Summary.make ()
   in
   CCResult.map_l of_version_1_notification_policy policies
@@ -3301,10 +3322,17 @@ let to_version_1_notification_policy policy =
 let to_version_1_notifications notifications =
   let module N = Terrat_repo_config.Notifications in
   let module Sn = Terrat_repo_config.Notifications_summary in
-  let { Notifications.policies; summary = { Notifications.Summary.enabled } } = notifications in
+  let { Notifications.policies; summary = { Notifications.Summary.enabled; mode } } =
+    notifications
+  in
+  let mode =
+    match mode with
+    | Notifications.Summary.Mode.Header -> `Header
+    | Notifications.Summary.Mode.Pull_request -> `Pull_request
+  in
   {
     N.policies = Some (CCList.map to_version_1_notification_policy policies);
-    summary = Some { Sn.enabled };
+    summary = Some { Sn.enabled; mode };
   }
 
 let to_version_1_storage_plans plans =

--- a/code/src/terrat_base_repo_config_v1/terrat_base_repo_config_v1.mli
+++ b/code/src/terrat_base_repo_config_v1/terrat_base_repo_config_v1.mli
@@ -675,13 +675,24 @@ module Notifications : sig
 
     type t = {
       tag_query : Tag_query.t;
-      comment_strategy : Strategy.t; [@default Strategy.Append]
+      comment_strategy : Strategy.t; [@default Strategy.Minimize]
     }
     [@@deriving make, show, yojson, eq]
   end
 
   module Summary : sig
-    type t = { enabled : bool [@default false] } [@@deriving make, show, yojson, eq]
+    module Mode : sig
+      type t =
+        | Header
+        | Pull_request
+      [@@deriving show, yojson, eq]
+    end
+
+    type t = {
+      enabled : bool; [@default false]
+      mode : Mode.t; [@default Mode.Header]
+    }
+    [@@deriving make, show, yojson, eq]
   end
 
   type t = {

--- a/code/src/terrat_github/terrat_github.ml
+++ b/code/src/terrat_github/terrat_github.ml
@@ -135,6 +135,13 @@ type minimize_comment_err =
   ]
 [@@deriving show]
 
+type update_comment_err =
+  [ Githubc2_abb.call_err
+  | `Not_found
+  | `Unprocessable_entity of Githubc2_components.Validation_error.t
+  ]
+[@@deriving show]
+
 type publish_reaction_err =
   [ Githubc2_abb.call_err
   | `Unprocessable_entity of Githubc2_components.Validation_error.t
@@ -552,6 +559,30 @@ let minimize_comment ~owner ~repo ~comment_id client =
           | `OK -> Abb.Future.return (Ok ())
           | `Not_found -> Abb.Future.return (Error `Not_found)))
   | `Not_found _ -> Abb.Future.return (Error `Not_found)
+
+let update_comment ~owner ~repo ~comment_id ~body client =
+  Prmths.Counter.inc_one (Metrics.fn_call_total "update_comment");
+  let open Abb.Future.Infix_monad in
+  (* No retries: a deleted comment comes back as an error (404) and retrying
+     it just delays the caller's fallback of posting a fresh comment. *)
+  call
+    ~tries:1
+    client
+    Githubc2_issues.Update_comment.(
+      make
+        ~body:Request_body.(make Primary.{ body })
+        Parameters.(make ~comment_id:(CCInt64.of_int comment_id) ~owner ~repo))
+  >>= function
+  | Ok resp -> (
+      match Openapi.Response.value resp with
+      | `OK _ -> Abb.Future.return (Ok ())
+      | `Unprocessable_entity _ as err -> Abb.Future.return (Error err))
+  | Error (`Missing_response resp) when Openapi.Response.status resp = 404 ->
+      (* A comment that has been deleted by the user comes back as a 404, which
+         the generated client does not have a response for, so detect that case
+         here. *)
+      Abb.Future.return (Error `Not_found)
+  | Error (#Githubc2_abb.call_err as err) -> Abb.Future.return (Error err)
 
 let react_to_comment ?(content = `Rocket) ~owner ~repo ~comment_id client =
   Prmths.Counter.inc_one (Metrics.fn_call_total "react_to_comment");

--- a/code/src/terrat_github/terrat_github.mli
+++ b/code/src/terrat_github/terrat_github.mli
@@ -91,6 +91,13 @@ type minimize_comment_err =
   ]
 [@@deriving show]
 
+type update_comment_err =
+  [ Githubc2_abb.call_err
+  | `Not_found
+  | `Unprocessable_entity of Githubc2_components.Validation_error.t
+  ]
+[@@deriving show]
+
 type publish_reaction_err =
   [ Githubc2_abb.call_err
   | `Unprocessable_entity of Githubc2_components.Validation_error.t
@@ -296,6 +303,14 @@ val minimize_comment :
   comment_id:int ->
   Githubc2_abb.t ->
   (unit, [> minimize_comment_err ]) result Abb.Future.t
+
+val update_comment :
+  owner:string ->
+  repo:string ->
+  comment_id:int ->
+  body:string ->
+  Githubc2_abb.t ->
+  (unit, [> update_comment_err ]) result Abb.Future.t
 
 val react_to_comment :
   ?content:Githubc2_reactions.Create_for_issue_comment.Request_body.Primary.Content.t ->

--- a/code/src/terrat_repo_config/terrat_repo_config_notifications_summary.ml
+++ b/code/src/terrat_repo_config/terrat_repo_config_notifications_summary.ml
@@ -1,2 +1,23 @@
-type t = { enabled : bool [@default false] }
+module Mode = struct
+  let t_of_yojson = function
+    | `String "header" -> Ok `Header
+    | `String "pull_request" -> Ok `Pull_request
+    | json -> Error ("Unknown value: " ^ Yojson.Safe.pretty_to_string json)
+
+  let t_to_yojson = function
+    | `Header -> `String "header"
+    | `Pull_request -> `String "pull_request"
+
+  type t =
+    ([ `Header
+     | `Pull_request
+     ]
+    [@of_yojson t_of_yojson] [@to_yojson t_to_yojson])
+  [@@deriving yojson { strict = false; meta = true }, show, eq]
+end
+
+type t = {
+  enabled : bool; [@default false]
+  mode : Mode.t; [@default `Header]
+}
 [@@deriving yojson { strict = true; meta = true }, make, show, eq]

--- a/code/src/terrat_vcs_api/terrat_vcs_api.ml
+++ b/code/src/terrat_vcs_api/terrat_vcs_api.ml
@@ -158,6 +158,14 @@ module type S = sig
     Comment.Id.t ->
     (unit, [> `Error ]) result Abb.Future.t
 
+  val update_pull_request_comment :
+    request_id:string ->
+    Client.t ->
+    ('diff, 'checks) Pull_request.t ->
+    Comment.Id.t ->
+    string ->
+    (unit, [> `Not_found | `Error ]) result Abb.Future.t
+
   val fetch_pull_request :
     request_id:string ->
     Account.t ->

--- a/code/src/terrat_vcs_api_github/terrat_vcs_api_github.ml
+++ b/code/src/terrat_vcs_api_github/terrat_vcs_api_github.ml
@@ -476,6 +476,27 @@ let minimize_pull_request_comment ~request_id client pull_request comment_id =
          want to block the actual commenting *)
       Abb.Future.return (Ok ())
 
+let update_pull_request_comment ~request_id client pull_request comment_id body =
+  let open Abb.Future.Infix_monad in
+  Terrat_github.update_comment
+    ~owner:(Repo.owner (Terrat_pull_request.repo pull_request))
+    ~repo:(Repo.name (Terrat_pull_request.repo pull_request))
+    ~comment_id
+    ~body
+    client.Client.client
+  >>= function
+  | Ok () -> Abb.Future.return (Ok ())
+  | Error `Not_found -> Abb.Future.return (Error `Not_found)
+  | Error (#Terrat_github.update_comment_err as err) ->
+      Prmths.Counter.inc_one Metrics.github_errors_total;
+      Logs.err (fun m ->
+          m
+            "%s : UPDATE_COMMENT_ON_PULL_REQUEST : %a"
+            request_id
+            Terrat_github.pp_update_comment_err
+            err);
+      Abb.Future.return (Error `Error)
+
 let diff_of_github_diff =
   CCList.map
     Githubc2_components.Diff_entry.(

--- a/code/src/terrat_vcs_api_gitlab/terrat_vcs_api_gitlab.ml
+++ b/code/src/terrat_vcs_api_gitlab/terrat_vcs_api_gitlab.ml
@@ -472,6 +472,9 @@ let delete_pull_request_comment ~request_id:_ _client _pull_request _comment_id 
 let minimize_pull_request_comment ~request_id:_ _client _pull_request _comment_id =
   raise (Failure "nyi")
 
+let update_pull_request_comment ~request_id:_ _client _pull_request _comment_id _body =
+  raise (Failure "nyi")
+
 let fetch_diff ~request_id ~client ~repo merge_request_iid =
   let module Gl =
     Gitlabc_projects_merge_requests.GetApiV4ProjectsIdMergeRequestsMergeRequestIidDiffs

--- a/code/src/terrat_vcs_api_nyi/terrat_vcs_api_nyi.ml
+++ b/code/src/terrat_vcs_api_nyi/terrat_vcs_api_nyi.ml
@@ -119,6 +119,10 @@ let fetch_tree ~request_id client repo ref_ = raise (Failure "nyi")
 let comment_on_pull_request ~request_id client pull_request body = raise (Failure "nyi")
 let delete_pull_request_comment ~request_id client pull_request comment_id = raise (Failure "nyi")
 let minimize_pull_request_comment ~request_id client pull_request comment_id = raise (Failure "nyi")
+
+let update_pull_request_comment ~request_id client pull_request comment_id body =
+  raise (Failure "nyi")
+
 let fetch_diff ~client ~owner ~repo pull_number = raise (Failure "nyi")
 let fetch_pull_request ~request_id account client repo pull_request_id = raise (Failure "nyi")
 let fetch_diff_files ~request_id ~base_ref ~branch_ref repo client = raise (Failure "nyi")

--- a/code/src/terrat_vcs_comment/dune
+++ b/code/src/terrat_vcs_comment/dune
@@ -1,5 +1,6 @@
 (library
  (name terrat_vcs_comment)
+ (wrapped false)
  (libraries abbs containers terrat_data terrat_dirspace)
  (preprocess
   (pps ppx_deriving.ord ppx_deriving.show)))

--- a/code/src/terrat_vcs_comment/terrat_vcs_comment_unified.ml
+++ b/code/src/terrat_vcs_comment/terrat_vcs_comment_unified.ml
@@ -1,0 +1,112 @@
+module Status = struct
+  type t =
+    | Failed
+    | Planned
+    | Pending
+    | Applied
+  [@@deriving ord, show]
+
+  let rank = function
+    | Failed -> 0
+    | Planned -> 1
+    | Pending -> 2
+    | Applied -> 3
+end
+
+module Tier = struct
+  type t =
+    | Details of int
+    | Table
+    | Truncated of int
+  [@@deriving ord, show]
+end
+
+module type S = sig
+  type t
+  type el [@@deriving ord, show]
+  type comment_id [@@deriving ord, show]
+
+  val query_comment_id : t -> (comment_id option, [> `Error ]) result Abb.Future.t
+  val query_els : t -> (el list, [> `Error ]) result Abb.Future.t
+  val render : t -> Tier.t -> el list -> string
+
+  val update_comment :
+    t -> comment_id -> string -> (unit, [> `Not_found | `Error ]) result Abb.Future.t
+
+  val post_comment : t -> string -> (comment_id, [> `Error ]) result Abb.Future.t
+  val upsert_comment_id : t -> comment_id -> (unit, [> `Error ]) result Abb.Future.t
+  val dirspace : el -> Terrat_dirspace.t
+  val status : el -> Status.t
+  val has_changes : el -> bool
+  val max_comment_length : int
+end
+
+module Make (M : S) = struct
+  let compare_el el1 el2 =
+    let module Cmp = struct
+      type t = int * bool * Terrat_dirspace.t [@@deriving ord]
+    end in
+    (* [not has_changes] so elements with changes sort first within a status *)
+    let key el = (Status.rank (M.status el), not (M.has_changes el), M.dirspace el) in
+    Cmp.compare (key el1) (key el2)
+
+  let sort_els els = CCList.sort compare_el els
+
+  (* Tiers from richest to most compact.  The last tier is used unconditionally
+     if nothing else fits, so it must always be renderable: a handful of table
+     rows plus a truncation notice. *)
+  let tiers els =
+    let n = CCList.length els in
+    CCList.filter_map
+      CCFun.id
+      [
+        Some (Tier.Details n);
+        (if n > 20 then Some (Tier.Details 20) else None);
+        (if n > 5 then Some (Tier.Details 5) else None);
+        Some Tier.Table;
+        (if n > 100 then Some (Tier.Truncated 100) else None);
+        (if n > 50 then Some (Tier.Truncated 50) else None);
+        Some (Tier.Truncated 10);
+      ]
+
+  let fit t els =
+    let rec first_fit = function
+      | [] -> assert false
+      | [ tier ] -> M.render t tier els
+      | tier :: rest ->
+          let body = M.render t tier els in
+          if CCString.length body < M.max_comment_length then body else first_fit rest
+    in
+    first_fit (tiers els)
+
+  let publish t body =
+    let open Abbs_future_combinators.Infix_result_monad in
+    let post_fresh t body =
+      M.post_comment t body >>= fun comment_id -> M.upsert_comment_id t comment_id
+    in
+    let open Abb.Future.Infix_monad in
+    M.query_comment_id t
+    >>= function
+    | Ok (Some comment_id) -> (
+        M.update_comment t comment_id body
+        >>= function
+        | Ok () -> Abb.Future.return (Ok ())
+        | Error `Not_found -> post_fresh t body
+        | Error `Error -> Abb.Future.return (Error `Error))
+    | Ok None -> post_fresh t body
+    | Error `Error -> Abb.Future.return (Error `Error)
+
+  let run t =
+    let open Abbs_future_combinators.Infix_result_monad in
+    M.query_els t
+    >>= function
+    | [] ->
+        (* Nothing to say about the pull request (for example the window
+           between a push and its run being created): leave the existing
+           comment untouched rather than publishing an empty table. *)
+        Abb.Future.return (Ok ())
+    | els ->
+        let sorted = sort_els els in
+        let body = fit t sorted in
+        publish t body
+end

--- a/code/src/terrat_vcs_comment/terrat_vcs_comment_unified.mli
+++ b/code/src/terrat_vcs_comment/terrat_vcs_comment_unified.mli
@@ -1,0 +1,71 @@
+(** Maintains a single "unified" summary comment for a pull request. Unlike {!Terrat_vcs_comment},
+    which tracks and consolidates the comments of individual work manifest results, this module
+    recomputes the state of every dirspace of the pull request from persistent storage on each
+    refresh and renders it into one comment which is updated in place. *)
+
+module Status : sig
+  (** The lifecycle state of a dirspace in the pull request, ordered by urgency: failures sort
+      before anything else, then plans awaiting an apply, then dirspaces that have not run yet, then
+      successfully applied ones. *)
+  type t =
+    | Failed
+    | Planned
+    | Pending
+    | Applied
+  [@@deriving ord, show]
+
+  val rank : t -> int
+end
+
+module Tier : sig
+  (** How much of the elements to render, from richest to most compact. [Details n] renders the
+      summary table plus inline output details for the first [n] elements in sorted order. [Table]
+      renders only the summary table. [Truncated n] renders only the first [n] table rows plus a
+      truncation notice. *)
+  type t =
+    | Details of int
+    | Table
+    | Truncated of int
+  [@@deriving ord, show]
+end
+
+module type S = sig
+  type t
+  type el [@@deriving ord, show]
+  type comment_id [@@deriving ord, show]
+
+  (** The tracked unified comment for the pull request, if one was posted. *)
+  val query_comment_id : t -> (comment_id option, [> `Error ]) result Abb.Future.t
+
+  (** Recompute the current state of every dirspace of the pull request. An empty result means the
+      state could not be established (for example the window between a new push and its run being
+      created) and the comment must be left untouched. *)
+  val query_els : t -> (el list, [> `Error ]) result Abb.Future.t
+
+  val render : t -> Tier.t -> el list -> string
+
+  (** [`Not_found] means the comment does not exist anymore (for example a user deleted it) and a
+      new one should be posted. *)
+  val update_comment :
+    t -> comment_id -> string -> (unit, [> `Not_found | `Error ]) result Abb.Future.t
+
+  val post_comment : t -> string -> (comment_id, [> `Error ]) result Abb.Future.t
+  val upsert_comment_id : t -> comment_id -> (unit, [> `Error ]) result Abb.Future.t
+
+  (** Element accessors used for sorting *)
+  val dirspace : el -> Terrat_dirspace.t
+
+  val status : el -> Status.t
+  val has_changes : el -> bool
+
+  (** Constraints *)
+  val max_comment_length : int
+end
+
+module Make (M : S) : sig
+  (** Sort elements by (status rank, has changes, dirspace). Exposed for the renderer so the table
+      and the details sections agree on the order. *)
+  val sort_els : M.el list -> M.el list
+
+  val run : M.t -> (unit, [> `Error ]) result Abb.Future.t
+end

--- a/code/src/terrat_vcs_event_evaluator2/terrat_vcs_event_evaluator2.ml
+++ b/code/src/terrat_vcs_event_evaluator2/terrat_vcs_event_evaluator2.ml
@@ -474,26 +474,44 @@ module Make (S : Terrat_vcs_provider2.S) = struct
               S.Db.query_flow_state ~request_id db work_manifest.Terrat_work_manifest3.id
               >>= function
               | Some _ -> Abb.Future.return (Ok (`Legacy work_manifest))
-              | None -> Abb.Future.return (Ok `New_age))
-          | None -> Abb.Future.return (Ok `New_age))
+              | None -> Abb.Future.return (Ok (`New_age (Some work_manifest))))
+          | None -> Abb.Future.return (Ok (`New_age None)))
       >>= function
-      | `New_age ->
+      | `New_age work_manifest ->
           with_conn storage ~f:(fun db ->
               Pgsql_io.tx db ~f:(fun () ->
                   let open Abb.Future.Infix_monad in
                   Builder.State.make ~log_id:request_id ~config ~store ~db ~exec ~tasks ()
                   >>= fun s ->
                   Logs.info (fun m -> m "%s : target=%s" (Builder.log_id s) (Hmap.Key.info target));
-                  tx_safe ~request_id @@ Builder.eval s target))
+                  tx_safe ~request_id @@ Builder.eval s target
+                  >>= fun r ->
+                  (* Best effort so the unified comment reflects the failure. *)
+                  match work_manifest with
+                  | Some { Terrat_work_manifest3.id; _ } ->
+                      S.Comment.mark_unified_comment_dirty ~request_id db id
+                      >>= fun _ -> Abb.Future.return r
+                  | None -> Abb.Future.return r))
+          >>= fun _ ->
+          Abb.Future.return
+            (Ok (CCOption.map (fun { Terrat_work_manifest3.id; _ } -> id) work_manifest))
       | `Legacy work_manifest ->
           let ctx = Legacy.Ctx.make ~config ~storage ~request_id () in
           Legacy.run_work_manifest_failure ~ctx work_manifest.Terrat_work_manifest3.id
-          >>= fun _ -> Abb.Future.return (Ok (`Ok ()))
+          >>= fun _ -> Abb.Future.return (Ok (Some work_manifest.Terrat_work_manifest3.id))
     in
     let open Abb.Future.Infix_monad in
     log_err ~request_id run
     >>= function
-    | Ok _ -> Abb.Future.return (Ok ())
+    | Ok work_manifest_id ->
+        CCOption.map_or
+          ~default:(Abb.Future.return ())
+          (fun work_manifest_id ->
+            Fc.ignore
+              (Abb.Future.fork
+                 (S.Comment.drain_unified_comment ~request_id config storage work_manifest_id)))
+          work_manifest_id
+        >>= fun () -> Abb.Future.return (Ok ())
     | Error _ -> Abb.Future.return (Error `Error)
 
   let compute_node_poll ~request_id ~config ~storage ~exec ~compute_node_id offering =
@@ -834,6 +852,10 @@ module Make (S : Terrat_vcs_provider2.S) = struct
                     work_manifest_id
                     Terrat_work_manifest3.State.Aborted
                   >>= fun () ->
+                  let open Abb.Future.Infix_monad in
+                  (* Best effort so the unified comment reflects the abort. *)
+                  S.Comment.mark_unified_comment_dirty ~request_id db work_manifest_id
+                  >>= fun _ ->
                   run_work_manifest_event
                     ~request_id
                     ~config
@@ -855,6 +877,19 @@ module Make (S : Terrat_vcs_provider2.S) = struct
         | Ok _ -> Abb.Future.return (Ok ())
         | Error _ -> Abb.Future.return (Error `Error))
       ~finally:(fun () ->
+        Fc.ignore
+          (Abb.Future.fork
+             (S.Comment.drain_unified_comment ~request_id config storage work_manifest_id))
+        >>= fun () ->
+        (* The legacy evaluator resolves its result future while its
+           transaction is still open, so the dirty mark may not be visible to
+           the drain above yet.  A delayed second drain picks it up. *)
+        Fc.ignore
+          (Abb.Future.fork
+             (Abb.Sys.sleep 10.0
+             >>= fun () ->
+             S.Comment.drain_unified_comment ~request_id config storage work_manifest_id))
+        >>= fun () ->
         Fc.ignore
         @@ Abb.Future.fork
         @@ run_missing_drift_schedules ~request_id ~config ~storage ~exec ())

--- a/code/src/terrat_vcs_github_comment/sql/clear_unified_comment_dirty.sql
+++ b/code/src/terrat_vcs_github_comment/sql/clear_unified_comment_dirty.sql
@@ -1,0 +1,4 @@
+update github_unified_comments
+set dirty = 0
+where repository = $repository and pull_number = $pull_number and dirty = $dirty
+returning repository

--- a/code/src/terrat_vcs_github_comment/sql/mark_unified_comment_dirty.sql
+++ b/code/src/terrat_vcs_github_comment/sql/mark_unified_comment_dirty.sql
@@ -1,0 +1,9 @@
+-- Bump the dirty counter of an existing unified comment row.  Unlike the
+-- upsert, this never creates a row: only pull requests that already publish a
+-- unified comment are refreshed.
+update github_unified_comments as guc
+set dirty = guc.dirty + 1
+from github_work_manifests as gwm
+where gwm.id = $work_manifest
+  and guc.repository = gwm.repository
+  and guc.pull_number = gwm.pull_number

--- a/code/src/terrat_vcs_github_comment/sql/select_unified_comment_elements.sql
+++ b/code/src/terrat_vcs_github_comment/sql/select_unified_comment_elements.sql
@@ -1,0 +1,156 @@
+-- Recompute the state of every dirspace of the pull request that the given
+-- work manifest belongs to, at the pull request's current sha.  The counts are
+-- extracted from the plan output summary line when present.
+with pr as (
+    select
+        gpr.repository,
+        gpr.pull_number,
+        gpr.base_sha,
+        gpr.sha,
+        gpr.merged_sha,
+        gpr.state,
+        grm.core_id as repo_core_id
+    from github_work_manifests as gwm
+    inner join github_pull_requests as gpr
+        on gpr.repository = gwm.repository and gpr.pull_number = gwm.pull_number
+    inner join github_repositories_map as grm
+        on grm.repository_id = gpr.repository
+    where gwm.id = $work_manifest
+),
+-- In the case that the pull request being evaluated here is merged, work
+-- manifests run against the sha of the most recently merged pull request, so
+-- accept that sha as well.
+latest_merged_pull_request as (
+    select gpr.repository, gpr.merged_sha
+    from github_pull_requests as gpr
+    inner join pr on pr.repository = gpr.repository
+    where gpr.state = 'merged'
+    order by gpr.merged_at desc
+    limit 1
+),
+current_dirspaces as (
+    select distinct cd.path, cd.workspace
+    from change_dirspaces as cd
+    inner join pr
+        on pr.repo_core_id = cd.repo and pr.base_sha = cd.base_sha
+    left join latest_merged_pull_request as lmpr
+        on lmpr.repository = pr.repository
+    where pr.sha = cd.sha
+          or pr.merged_sha = cd.sha
+          or (pr.state = 'merged' and cd.sha = lmpr.merged_sha)
+),
+pr_work_manifests as (
+    select gwm.id, gwm.run_type, gwm.state, gwm.created_at
+    from github_work_manifests as gwm
+    inner join pr
+        on pr.repository = gwm.repository
+           and pr.pull_number = gwm.pull_number
+           and pr.base_sha = gwm.base_sha
+    left join latest_merged_pull_request as lmpr
+        on lmpr.repository = pr.repository
+    left join github_pull_request_latest_unlocks as lu
+        on lu.repository = gwm.repository and lu.pull_number = gwm.pull_number
+    where (pr.sha = gwm.sha
+           or pr.merged_sha = gwm.sha
+           or (pr.state = 'merged' and gwm.sha = lmpr.merged_sha))
+          and gwm.run_type in ('plan', 'autoplan', 'apply', 'autoapply', 'unsafe-apply')
+          and (lu.unlocked_at is null or lu.unlocked_at < gwm.created_at)
+),
+latest_plans as (
+    select path, workspace, success, work_manifest
+    from (
+        select
+            wmr.path,
+            wmr.workspace,
+            wmr.success,
+            wm.id as work_manifest,
+            row_number() over (partition by wmr.path, wmr.workspace
+                               order by wm.created_at desc) as rn
+        from pr_work_manifests as wm
+        inner join work_manifest_results as wmr
+            on wmr.work_manifest = wm.id
+        where wm.run_type in ('plan', 'autoplan')
+    ) as t
+    where rn = 1
+),
+latest_applies as (
+    select path, workspace, success, work_manifest
+    from (
+        select
+            wmr.path,
+            wmr.workspace,
+            wmr.success,
+            wm.id as work_manifest,
+            row_number() over (partition by wmr.path, wmr.workspace
+                               order by wm.created_at desc) as rn
+        from pr_work_manifests as wm
+        inner join work_manifest_results as wmr
+            on wmr.work_manifest = wm.id
+        where wm.run_type in ('apply', 'autoapply', 'unsafe-apply')
+    ) as t
+    where rn = 1
+),
+active_dirspaces as (
+    select distinct wmd.path, wmd.workspace
+    from pr_work_manifests as wm
+    inner join work_manifest_dirspaceflows as wmd
+        on wmd.work_manifest = wm.id
+    where wm.state in ('queued', 'running')
+),
+aborted_dirspaces as (
+    select distinct wmd.path, wmd.workspace
+    from pr_work_manifests as wm
+    inner join work_manifest_dirspaceflows as wmd
+        on wmd.work_manifest = wm.id
+    where wm.state = 'aborted'
+      and not exists (select 1
+                      from work_manifest_results as wmr
+                      where wmr.work_manifest = wm.id)
+)
+select
+    cd.path,
+    cd.workspace,
+    lp.success as plan_success,
+    -- The plans row is deleted once an apply fetches the plan, so fall back to
+    -- the plan step output which is retained forever.
+    coalesce(p.has_changes, (po.payload->>'has_changes')::boolean) as plan_has_changes,
+    lp.work_manifest as plan_work_manifest,
+    -- Exact resource-change counts, computed by the runner from
+    -- `terraform show -json`.  No text parsing: when a runner or engine does
+    -- not emit them the columns are null (rendered as "-") rather than guessed.
+    (po.payload->'resource_summary'->>'created')::bigint as created,
+    (po.payload->'resource_summary'->>'updated')::bigint as updated,
+    (po.payload->'resource_summary'->>'deleted')::bigint as deleted,
+    (po.payload->'resource_summary'->>'replaced')::bigint as replaced,
+    -- Inline output details are only rendered for small pull requests; at
+    -- scale the unified comment is a table with console links.
+    case when (select count(*) from current_dirspaces) <= 20 then
+        coalesce(po.payload->>'plan', po.payload->>'text')
+    end as plan_output,
+    la.success as apply_success,
+    la.work_manifest as apply_work_manifest,
+    (ad.path is not null) as active,
+    (ab.path is not null) as aborted
+from current_dirspaces as cd
+left join latest_plans as lp
+    on lp.path = cd.path and lp.workspace = cd.workspace
+left join plans as p
+    on p.work_manifest = lp.work_manifest and p.path = lp.path and p.workspace = lp.workspace
+left join lateral (
+    select wso.payload
+    from workflow_step_outputs as wso
+    where wso.work_manifest = lp.work_manifest
+      and wso.scope->>'type' = 'dirspace'
+      and wso.scope->>'dir' = lp.path
+      and wso.scope->>'workspace' = lp.workspace
+      and wso.step in ('tf/plan', 'pulumi/plan', 'custom/plan', 'fly/plan', 'stategraph/plan')
+    order by wso.idx desc
+    limit 1
+) as po on true
+left join latest_applies as la
+    on la.path = cd.path and la.workspace = cd.workspace
+left join active_dirspaces as ad
+    on ad.path = cd.path and ad.workspace = cd.workspace
+left join aborted_dirspaces as ab
+    on ab.path = cd.path and ab.workspace = cd.workspace
+order by cd.path, cd.workspace

--- a/code/src/terrat_vcs_github_comment/sql/select_unified_comment_state.sql
+++ b/code/src/terrat_vcs_github_comment/sql/select_unified_comment_state.sql
@@ -1,0 +1,12 @@
+select
+    gwm.repository,
+    gwm.pull_number,
+    gwm.installation_id,
+    gwm.repo_owner,
+    gwm.repo_name,
+    guc.comment_id,
+    guc.dirty
+from github_work_manifests as gwm
+inner join github_unified_comments as guc
+    on guc.repository = gwm.repository and guc.pull_number = gwm.pull_number
+where gwm.id = $work_manifest

--- a/code/src/terrat_vcs_github_comment/sql/update_unified_comment_id.sql
+++ b/code/src/terrat_vcs_github_comment/sql/update_unified_comment_id.sql
@@ -1,0 +1,3 @@
+update github_unified_comments
+set comment_id = $comment_id
+where repository = $repository and pull_number = $pull_number

--- a/code/src/terrat_vcs_github_comment/sql/upsert_unified_comment_dirty.sql
+++ b/code/src/terrat_vcs_github_comment/sql/upsert_unified_comment_dirty.sql
@@ -1,0 +1,9 @@
+insert into github_unified_comments (repository, pull_number, dirty)
+select
+    gwm.repository,
+    gwm.pull_number,
+    1
+from github_work_manifests as gwm
+where gwm.id = $work_manifest and gwm.pull_number is not null
+on conflict (repository, pull_number)
+do update set dirty = github_unified_comments.dirty + 1

--- a/code/src/terrat_vcs_github_comment/terrat_vcs_github_comment_ui.mli
+++ b/code/src/terrat_vcs_github_comment/terrat_vcs_github_comment_ui.mli
@@ -1,4 +1,6 @@
 module Ui : sig
+  val base_url : Terrat_vcs_api_github.Config.t -> Terrat_vcs_api_github.Account.t -> string
+
   val work_manifest_url :
     Terrat_vcs_api_github.Config.t ->
     Terrat_vcs_api_github.Account.t ->

--- a/code/src/terrat_vcs_github_comment/terrat_vcs_github_comment_unified.ml
+++ b/code/src/terrat_vcs_github_comment/terrat_vcs_github_comment_unified.ml
@@ -1,0 +1,529 @@
+module Api = Terrat_vcs_api_github
+module Tmpl = Terrat_vcs_github_comment_templates.Tmpl
+module Ui = Terrat_vcs_github_comment_ui.Ui
+module Unified = Terrat_vcs_comment_unified
+
+let src = Logs.Src.create "vcs_github_comment_unified"
+
+module Logs = (val Logs.src_log src : Logs.LOG)
+
+module Sql = struct
+  let read s = Pgsql_io.clean_string s
+
+  let upsert_unified_comment_dirty =
+    Pgsql_io.Typed_sql.(
+      sql /^ read [%blob "sql/upsert_unified_comment_dirty.sql"] /% Var.uuid "work_manifest")
+
+  let mark_unified_comment_dirty =
+    Pgsql_io.Typed_sql.(
+      sql /^ read [%blob "sql/mark_unified_comment_dirty.sql"] /% Var.uuid "work_manifest")
+
+  let select_unified_comment_state =
+    Pgsql_io.Typed_sql.(
+      sql
+      //
+      (* repository *)
+      Ret.bigint
+      //
+      (* pull_number *)
+      Ret.bigint
+      //
+      (* installation_id *)
+      Ret.bigint
+      //
+      (* repo_owner *)
+      Ret.text
+      //
+      (* repo_name *)
+      Ret.text
+      //
+      (* comment_id *)
+      Ret.(option bigint)
+      //
+      (* dirty *)
+      Ret.bigint
+      /^ read [%blob "sql/select_unified_comment_state.sql"]
+      /% Var.uuid "work_manifest")
+
+  let select_unified_comment_elements () =
+    Pgsql_io.Typed_sql.(
+      sql
+      //
+      (* path *)
+      Ret.text
+      //
+      (* workspace *)
+      Ret.text
+      //
+      (* plan_success *)
+      Ret.(option boolean)
+      //
+      (* plan_has_changes *)
+      Ret.(option boolean)
+      //
+      (* plan_work_manifest *)
+      Ret.(option uuid)
+      //
+      (* created *)
+      Ret.(option bigint)
+      //
+      (* updated *)
+      Ret.(option bigint)
+      //
+      (* deleted *)
+      Ret.(option bigint)
+      //
+      (* replaced *)
+      Ret.(option bigint)
+      //
+      (* plan_output *)
+      Ret.(option text)
+      //
+      (* apply_success *)
+      Ret.(option boolean)
+      //
+      (* apply_work_manifest *)
+      Ret.(option uuid)
+      //
+      (* active *)
+      Ret.boolean
+      //
+      (* aborted *)
+      Ret.boolean
+      /^ read [%blob "sql/select_unified_comment_elements.sql"]
+      /% Var.uuid "work_manifest")
+
+  let update_unified_comment_id =
+    Pgsql_io.Typed_sql.(
+      sql
+      /^ read [%blob "sql/update_unified_comment_id.sql"]
+      /% Var.bigint "comment_id"
+      /% Var.bigint "repository"
+      /% Var.bigint "pull_number")
+
+  let clear_unified_comment_dirty =
+    Pgsql_io.Typed_sql.(
+      sql
+      //
+      (* repository *)
+      Ret.bigint
+      /^ read [%blob "sql/clear_unified_comment_dirty.sql"]
+      /% Var.bigint "repository"
+      /% Var.bigint "pull_number"
+      /% Var.bigint "dirty")
+
+  let try_advisory_lock =
+    Pgsql_io.Typed_sql.(
+      sql
+      //
+      (* locked *)
+      Ret.boolean
+      /^ "select pg_try_advisory_xact_lock(hashtext('github_unified_comments'), hashtext($key))"
+      /% Var.text "key")
+end
+
+module S = struct
+  type t = {
+    account : Api.Account.t;
+    client : Githubc2_abb.t;
+    comment_id : Api.Comment.Id.t option;
+    config : Api.Config.t;
+    db : Pgsql_io.t;
+    pull_number : int64;
+    repo_name : string;
+    repo_owner : string;
+    repository : int64;
+    request_id : string;
+    work_manifest_id : Uuidm.t;
+  }
+
+  type el = {
+    created : int64 option;
+    deleted : int64 option;
+    dirspace : Terrat_dirspace.t;
+    has_changes : bool;
+    output : string option;
+    replaced : int64 option;
+    status : Unified.Status.t;
+    updated : int64 option;
+    work_manifest_id : Uuidm.t option;
+  }
+  [@@deriving ord, show]
+
+  type comment_id = Api.Comment.Id.t [@@deriving ord, show]
+
+  let status_of_row ~plan_success ~apply_success ~active ~aborted =
+    let module St = Unified.Status in
+    match (apply_success, active, plan_success) with
+    | Some true, _, _ -> St.Applied
+    | Some false, _, _ -> St.Failed
+    | None, true, _ -> St.Pending
+    | None, false, Some false -> St.Failed
+    | None, false, Some true -> St.Planned
+    | None, false, None -> if aborted then St.Failed else St.Pending
+
+  let query_comment_id t = Abb.Future.return (Ok t.comment_id)
+
+  let query_els t =
+    let open Abb.Future.Infix_monad in
+    Pgsql_io.Prepared_stmt.fetch
+      t.db
+      (Sql.select_unified_comment_elements ())
+      ~f:(fun
+          path
+          workspace
+          plan_success
+          plan_has_changes
+          plan_work_manifest
+          created
+          updated
+          deleted
+          replaced
+          plan_output
+          apply_success
+          apply_work_manifest
+          active
+          aborted
+        ->
+        {
+          created;
+          deleted;
+          dirspace = { Terrat_dirspace.dir = path; workspace };
+          has_changes = CCOption.get_or ~default:false plan_has_changes;
+          output = plan_output;
+          replaced;
+          status = status_of_row ~plan_success ~apply_success ~active ~aborted;
+          updated;
+          work_manifest_id = CCOption.or_ ~else_:plan_work_manifest apply_work_manifest;
+        })
+      t.work_manifest_id
+    >>= function
+    | Ok _ as r -> Abb.Future.return r
+    | Error (#Pgsql_io.err as err) ->
+        Logs.err (fun m -> m "%s : ERROR : %a" t.request_id Pgsql_io.pp_err err);
+        Abb.Future.return (Error `Error)
+
+  let status_kv status =
+    let module St = Unified.Status in
+    match status with
+    | St.Failed -> ":x: **Failed**"
+    | St.Planned -> ":pencil2: Planned"
+    | St.Pending -> ":hourglass_flowing_sand: Pending"
+    | St.Applied -> ":white_check_mark: Applied"
+
+  let status_machine status =
+    let module St = Unified.Status in
+    match status with
+    | St.Failed -> "failed"
+    | St.Planned -> "planned"
+    | St.Pending -> "pending"
+    | St.Applied -> "applied"
+
+  let count_kv el count =
+    match (el.status, el.has_changes, count) with
+    | Unified.Status.Pending, _, _ | _, false, _ | _, _, None -> "-"
+    | _, true, Some n -> Int64.to_string n
+
+  let run_url t el =
+    CCOption.map
+      (fun work_manifest_id ->
+        Uri.to_string
+        @@ CCOption.get_exn_or "run_url"
+        @@ Ui.run_url t.config t.account work_manifest_id)
+      el.work_manifest_id
+
+  let console_url t = Printf.sprintf "%s/runs/pr/%Ld" (Ui.base_url t.config t.account) t.pull_number
+
+  let sum f els =
+    CCList.fold_left (fun acc el -> Int64.add acc (CCOption.get_or ~default:0L (f el))) 0L els
+
+  let machine_kv t els =
+    let json =
+      `Assoc
+        [
+          ( "dirspaces",
+            `List
+              (CCList.map
+                 (fun el ->
+                   let { Terrat_dirspace.dir; workspace } = el.dirspace in
+                   `Assoc
+                     [
+                       ("dir", `String dir);
+                       ("workspace", `String workspace);
+                       ("status", `String (status_machine el.status));
+                       ("has_changes", `Bool el.has_changes);
+                       ( "created",
+                         CCOption.map_or ~default:`Null (fun n -> `Intlit (Int64.to_string n))
+                         @@ el.created );
+                       ( "updated",
+                         CCOption.map_or ~default:`Null (fun n -> `Intlit (Int64.to_string n))
+                         @@ el.updated );
+                       ( "deleted",
+                         CCOption.map_or ~default:`Null (fun n -> `Intlit (Int64.to_string n))
+                         @@ el.deleted );
+                       ( "replaced",
+                         CCOption.map_or ~default:`Null (fun n -> `Intlit (Int64.to_string n))
+                         @@ el.replaced );
+                       ( "run_url",
+                         CCOption.map_or ~default:`Null (fun url -> `String url) @@ run_url t el );
+                     ])
+                 els) );
+        ]
+    in
+    (* "--" may not appear inside an HTML comment; encode it away using JSON
+       unicode escapes so the payload stays valid JSON. *)
+    CCString.replace ~sub:"--" ~by:"\\u002d\\u002d" (Yojson.Safe.to_string json)
+
+  let render t tier els =
+    let module T = Unified.Tier in
+    let num_els = CCList.length els in
+    let shown =
+      match tier with
+      | T.Details _ | T.Table -> els
+      | T.Truncated n -> CCList.take n els
+    in
+    let details =
+      match tier with
+      | T.Details n ->
+          CCList.filter (fun el -> not (CCOption.is_none el.output)) (CCList.take n els)
+      | T.Table | T.Truncated _ -> []
+    in
+    let count_status status =
+      CCList.length (CCList.filter (fun el -> Unified.Status.compare el.status status = 0) els)
+    in
+    let kv =
+      `Assoc
+        [
+          ("num_dirspaces", `Int num_els);
+          ("num_failed", `Int (count_status Unified.Status.Failed));
+          ("num_planned", `Int (count_status Unified.Status.Planned));
+          ("num_pending", `Int (count_status Unified.Status.Pending));
+          ("num_applied", `Int (count_status Unified.Status.Applied));
+          ( "dirspaces",
+            `List
+              (CCList.map
+                 (fun el ->
+                   let { Terrat_dirspace.dir; workspace } = el.dirspace in
+                   `Assoc
+                     [
+                       ("dir", `String dir);
+                       ("workspace", `String workspace);
+                       ("status", `String (status_kv el.status));
+                       ("created", `String (count_kv el el.created));
+                       ("updated", `String (count_kv el el.updated));
+                       ("replaced", `String (count_kv el el.replaced));
+                       ("deleted", `String (count_kv el el.deleted));
+                       ( "run_url",
+                         CCOption.map_or ~default:`Null (fun url -> `String url) @@ run_url t el );
+                     ])
+                 shown) );
+          ( "totals",
+            `Assoc
+              [
+                ("created", `String (Int64.to_string (sum (fun el -> el.created) els)));
+                ("updated", `String (Int64.to_string (sum (fun el -> el.updated) els)));
+                ("replaced", `String (Int64.to_string (sum (fun el -> el.replaced) els)));
+                ("deleted", `String (Int64.to_string (sum (fun el -> el.deleted) els)));
+              ] );
+          ("truncated", `Int (num_els - CCList.length shown));
+          ("console_url", `String (console_url t));
+          ( "details",
+            `List
+              (CCList.map
+                 (fun el ->
+                   let { Terrat_dirspace.dir; workspace } = el.dirspace in
+                   `Assoc
+                     [
+                       ("dir", `String dir);
+                       ("workspace", `String workspace);
+                       ("output", `String (CCOption.get_or ~default:"" el.output));
+                     ])
+                 details) );
+          ( "show_apply_hint",
+            `Bool
+              (CCList.exists
+                 (fun el ->
+                   Unified.Status.compare el.status Unified.Status.Planned = 0 && el.has_changes)
+                 els) );
+          ( "machine",
+            match tier with
+            | T.Details _ | T.Table -> `String (machine_kv t els)
+            | T.Truncated _ -> `Null );
+        ]
+    in
+    match Minijinja.render_template Tmpl.unified_comment kv with
+    | Ok body -> body
+    | Error err ->
+        Logs.err (fun m -> m "%s : ERROR : %s" t.request_id err);
+        assert false
+
+  let update_comment t comment_id body =
+    let open Abb.Future.Infix_monad in
+    Terrat_github.update_comment
+      ~owner:t.repo_owner
+      ~repo:t.repo_name
+      ~comment_id:
+        (Api.Comment.Id.to_string comment_id |> CCInt.of_string |> CCOption.get_exn_or "comment_id")
+      ~body
+      t.client
+    >>= function
+    | Ok () -> Abb.Future.return (Ok ())
+    | Error `Not_found -> Abb.Future.return (Error `Not_found)
+    | Error (#Terrat_github.update_comment_err as err) ->
+        Logs.err (fun m -> m "%s : ERROR : %a" t.request_id Terrat_github.pp_update_comment_err err);
+        Abb.Future.return (Error `Error)
+
+  let post_comment t body =
+    let open Abb.Future.Infix_monad in
+    Terrat_github.publish_comment
+      ~owner:t.repo_owner
+      ~repo:t.repo_name
+      ~pull_number:(CCInt64.to_int t.pull_number)
+      ~body
+      t.client
+    >>= function
+    | Ok comment_id -> (
+        match Api.Comment.Id.of_string (CCInt.to_string comment_id) with
+        | Some comment_id -> Abb.Future.return (Ok comment_id)
+        | None -> Abb.Future.return (Error `Error))
+    | Error (#Terrat_github.publish_comment_err as err) ->
+        Logs.err (fun m ->
+            m "%s : ERROR : %a" t.request_id Terrat_github.pp_publish_comment_err err);
+        Abb.Future.return (Error `Error)
+
+  let upsert_comment_id t comment_id =
+    let open Abb.Future.Infix_monad in
+    Pgsql_io.Prepared_stmt.execute
+      t.db
+      Sql.update_unified_comment_id
+      (Int64.of_int
+         (Api.Comment.Id.to_string comment_id |> CCInt.of_string |> CCOption.get_exn_or "comment_id"))
+      t.repository
+      t.pull_number
+    >>= function
+    | Ok () -> Abb.Future.return (Ok ())
+    | Error (#Pgsql_io.err as err) ->
+        Logs.err (fun m -> m "%s : ERROR : %a" t.request_id Pgsql_io.pp_err err);
+        Abb.Future.return (Error `Error)
+
+  let dirspace el = el.dirspace
+  let status el = el.status
+  let has_changes el = el.has_changes
+
+  (* GitHub limits comments to 65536 characters.  Leave some margin for
+     good measure. *)
+  let max_comment_length = 65536 - 512
+end
+
+module Publisher = Unified.Make (S)
+
+let mark_dirty ~request_id db work_manifest_id =
+  let open Abb.Future.Infix_monad in
+  Pgsql_io.Prepared_stmt.execute db Sql.upsert_unified_comment_dirty work_manifest_id
+  >>= function
+  | Ok () -> Abb.Future.return (Ok ())
+  | Error (#Pgsql_io.err as err) ->
+      Logs.err (fun m -> m "%s : ERROR : %a" request_id Pgsql_io.pp_err err);
+      Abb.Future.return (Error `Error)
+
+let mark_dirty_if_tracked ~request_id db work_manifest_id =
+  let open Abb.Future.Infix_monad in
+  Pgsql_io.Prepared_stmt.execute db Sql.mark_unified_comment_dirty work_manifest_id
+  >>= function
+  | Ok () -> Abb.Future.return (Ok ())
+  | Error (#Pgsql_io.err as err) ->
+      Logs.err (fun m -> m "%s : ERROR : %a" request_id Pgsql_io.pp_err err);
+      Abb.Future.return (Error `Error)
+
+(* One refresh attempt.  Runs in its own transaction on its own connection so
+   the advisory lock and the GitHub API calls never extend a result
+   transaction.  Returns [`Race] when new results marked the comment dirty
+   while we were publishing, in which case the caller retries. *)
+let refresh ~request_id config storage work_manifest_id =
+  let open Abbs_future_combinators.Infix_result_monad in
+  Pgsql_pool.with_conn storage ~f:(fun db ->
+      Pgsql_io.tx db ~f:(fun () ->
+          Pgsql_io.Prepared_stmt.fetch
+            db
+            Sql.select_unified_comment_state
+            ~f:(fun repository pull_number installation_id repo_owner repo_name comment_id dirty ->
+              (repository, pull_number, installation_id, repo_owner, repo_name, comment_id, dirty))
+            work_manifest_id
+          >>= function
+          | [] | (_, _, _, _, _, _, 0L) :: _ -> Abb.Future.return (Ok `Done)
+          | (repository, pull_number, installation_id, repo_owner, repo_name, comment_id, dirty)
+            :: _ -> (
+              let key = Printf.sprintf "%Ld:%Ld" repository pull_number in
+              Pgsql_io.Prepared_stmt.fetch db Sql.try_advisory_lock ~f:CCFun.id key
+              >>= function
+              | [ false ] ->
+                  (* Another drain is publishing; it will pick up our dirty
+                     mark or the next result will. *)
+                  Abb.Future.return (Ok `Done)
+              | _ -> (
+                  let account = Api.Account.make (CCInt64.to_int installation_id) in
+                  Api.create_client ~request_id config account db
+                  >>= fun client ->
+                  let t =
+                    {
+                      S.account;
+                      client = Api.Client.to_native client;
+                      comment_id =
+                        CCOption.flat_map
+                          CCFun.(Int64.to_string %> Api.Comment.Id.of_string)
+                          comment_id;
+                      config;
+                      db;
+                      pull_number;
+                      repo_name;
+                      repo_owner;
+                      repository;
+                      request_id;
+                      work_manifest_id;
+                    }
+                  in
+                  Publisher.run t
+                  >>= fun () ->
+                  Pgsql_io.Prepared_stmt.fetch
+                    db
+                    Sql.clear_unified_comment_dirty
+                    ~f:CCFun.id
+                    repository
+                    pull_number
+                    dirty
+                  >>= function
+                  | [] -> Abb.Future.return (Ok `Race)
+                  | _ :: _ -> Abb.Future.return (Ok `Done)))))
+
+let drain ~request_id config storage work_manifest_id =
+  let open Abb.Future.Infix_monad in
+  let rec attempt n =
+    if n <= 0 then (
+      (* The dirty counter is still set; the next drain of this pull request
+         picks it up. *)
+      Logs.warn (fun m ->
+          m
+            "%s : DRAIN_UNIFIED_COMMENT : RETRIES_EXHAUSTED : %a"
+            request_id
+            Uuidm.pp
+            work_manifest_id);
+      Abb.Future.return (Ok `Done))
+    else
+      refresh ~request_id config storage work_manifest_id
+      >>= function
+      | Ok `Done -> Abb.Future.return (Ok `Done)
+      | Ok `Race -> attempt (n - 1)
+      | Error _ as err -> Abb.Future.return err
+  in
+  attempt 3
+  >>= function
+  | Ok `Done -> Abb.Future.return ()
+  | Error `Error ->
+      Logs.err (fun m -> m "%s : DRAIN_UNIFIED_COMMENT : ERROR" request_id);
+      Abb.Future.return ()
+  | Error (#Pgsql_pool.err as err) ->
+      Logs.err (fun m -> m "%s : DRAIN_UNIFIED_COMMENT : %a" request_id Pgsql_pool.pp_err err);
+      Abb.Future.return ()
+  | Error (#Pgsql_io.err as err) ->
+      Logs.err (fun m -> m "%s : DRAIN_UNIFIED_COMMENT : %a" request_id Pgsql_io.pp_err err);
+      Abb.Future.return ()

--- a/code/src/terrat_vcs_github_comment/terrat_vcs_github_comment_unified.mli
+++ b/code/src/terrat_vcs_github_comment/terrat_vcs_github_comment_unified.mli
@@ -1,0 +1,25 @@
+(** GitHub implementation of the unified pull request summary comment.
+
+    The flow has two halves. While a work manifest result is being processed (inside its
+    transaction), {!mark_dirty} bumps the dirty counter of the pull request's tracking row so the
+    refresh is committed atomically with the results. After the transaction commits, {!drain} runs
+    on a fresh connection: it takes an advisory lock so only one publisher runs per pull request,
+    recomputes the state of every dirspace, renders it, updates the tracked comment in place
+    (posting a new one if it disappeared), and clears the dirty counter it observed. If new results
+    arrived while publishing, the counter no longer matches and it retries. *)
+
+val mark_dirty :
+  request_id:string -> Pgsql_io.t -> Uuidm.t -> (unit, [> `Error ]) result Abb.Future.t
+
+(** Like {!mark_dirty} but never creates the tracking row, so pull requests that do not publish a
+    unified comment are unaffected. Used by failure paths, which cannot cheaply consult the repo
+    config. *)
+val mark_dirty_if_tracked :
+  request_id:string -> Pgsql_io.t -> Uuidm.t -> (unit, [> `Error ]) result Abb.Future.t
+
+val drain :
+  request_id:string ->
+  Terrat_vcs_api_github.Config.t ->
+  Pgsql_pool.t ->
+  Uuidm.t ->
+  unit Abb.Future.t

--- a/code/src/terrat_vcs_github_comment_templates/terrat_vcs_github_comment_templates.ml
+++ b/code/src/terrat_vcs_github_comment_templates/terrat_vcs_github_comment_templates.ml
@@ -182,6 +182,7 @@ module Tmpl = struct
 
   let plan_complete2 = jinja [%blob "tmpl/plan_complete2.tmpl"]
   let apply_complete2 = jinja [%blob "tmpl/apply_complete2.tmpl"]
+  let unified_comment = jinja [%blob "tmpl/unified_comment.tmpl"]
   let automerge_failure = read [%blob "tmpl/automerge_error.tmpl"]
 
   let premium_feature_err_access_control =

--- a/code/src/terrat_vcs_github_comment_templates/tmpl/unified_comment.tmpl
+++ b/code/src/terrat_vcs_github_comment_templates/tmpl/unified_comment.tmpl
@@ -1,0 +1,43 @@
+# Terrateam Summary
+
+**{{ num_dirspaces }} dirspace{{ 's' if num_dirspaces != 1 else '' }}** · {{ num_failed }} failed · {{ num_planned }} planned · {{ num_pending }} pending · {{ num_applied }} applied
+
+| Directory | Workspace | Status | Created | Updated | Replaced | Deleted |
+| --- | --- | :---: | :---: | :---: | :---: | :---: |
+{%- for d in dirspaces %}
+| {% if d.run_url %}[`{{ d.dir }}`]({{ d.run_url }}){% else %}`{{ d.dir }}`{% endif %} | `{{ d.workspace }}` | {{ d.status }} | {{ d.created }} | {{ d.updated }} | {{ d.replaced }} | {{ d.deleted }} |
+{%- endfor %}
+| **Total** | | | **{{ totals.created }}** | **{{ totals.updated }}** | **{{ totals.replaced }}** | **{{ totals.deleted }}** |
+{%- if truncated > 0 %}
+
+… {{ truncated }} more dirspace{{ 's' if truncated != 1 else '' }} not shown{% if console_url %} — see the [Terrateam Console]({{ console_url }}){% endif %}.
+{%- endif %}
+{%- if details %}
+
+## Output details
+{%- for d in details %}
+
+<details>
+  <summary>{{ d.dir }} | {{ d.workspace }}</summary>
+
+```diff
+{{ d.output }}
+```
+
+</details>
+{%- endfor %}
+{%- endif %}
+{%- if show_apply_hint %}
+
+---
+
+To apply all these changes, comment:
+
+```
+terrateam apply
+```
+{%- endif %}
+{%- if machine %}
+
+<!-- terrateam:unified:v1 {{ machine }} -->
+{%- endif %}

--- a/code/src/terrat_vcs_provider2/dune
+++ b/code/src/terrat_vcs_provider2/dune
@@ -4,6 +4,8 @@
   abb
   jsonu
   pgsql_io
+  pgsql_pool
+  uuidm
   str_template
   terrat_access_control2
   terrat_api

--- a/code/src/terrat_vcs_provider2/terrat_vcs_provider2.ml
+++ b/code/src/terrat_vcs_provider2/terrat_vcs_provider2.ml
@@ -513,6 +513,18 @@ module type S = sig
         Api.Config.t )
       Msg.t ->
       (unit, [> `Error ]) result Abb.Future.t
+
+    (** Refresh the unified summary comment of the pull request the given work manifest belongs to,
+        if it has been marked dirty. Runs on its own connections after the result transaction
+        commits and is best effort: it must log and swallow its errors. *)
+    val drain_unified_comment :
+      request_id:string -> Api.Config.t -> Pgsql_pool.t -> Uuidm.t -> unit Abb.Future.t
+
+    (** Mark the unified summary comment of the work manifest's pull request as needing a refresh,
+        but only if the pull request already tracks one. Used by failure paths so aborted runs show
+        up in the comment. *)
+    val mark_unified_comment_dirty :
+      request_id:string -> Db.t -> Uuidm.t -> (unit, [> `Error ]) result Abb.Future.t
   end
 
   module Repo_config : sig

--- a/code/src/terrat_vcs_provider2_nyi/terrat_vcs_provider2_nyi.ml
+++ b/code/src/terrat_vcs_provider2_nyi/terrat_vcs_provider2_nyi.ml
@@ -99,6 +99,8 @@ end
 
 module Comment = struct
   let publish_comment ~request_id client user pull_request msg = raise (Failure "nyi")
+  let drain_unified_comment ~request_id config storage work_manifest_id = raise (Failure "nyi")
+  let mark_unified_comment_dirty ~request_id db work_manifest_id = raise (Failure "nyi")
 end
 
 module Repo_config = struct

--- a/code/src/terrat_vcs_service_github/sql/delete_repo.sql
+++ b/code/src/terrat_vcs_service_github/sql/delete_repo.sql
@@ -22,6 +22,13 @@ delete_work_manifest_comments as (
         and gir.id = $repo_id
         and gir.installation_id = $installation_id
 ),
+delete_unified_comments as (
+    delete from github_unified_comments
+    using github_installation_repositories as gir
+    where github_unified_comments.repository = gir.id
+        and gir.id = $repo_id
+        and gir.installation_id = $installation_id
+),
 delete_plans as (
     delete from plans
     using work_manifests as wm, repo as r

--- a/code/src/terrat_vcs_service_github/terrat_vcs_service_github_provider.ml
+++ b/code/src/terrat_vcs_service_github/terrat_vcs_service_github_provider.ml
@@ -4065,22 +4065,51 @@ module Comment = struct
           work_manifest;
         } -> (
         let open Abb.Future.Infix_monad in
-        Result.Publisher3.post_comment
-          request_id
-          account_status
-          config
-          client
-          db
-          is_layered_run
-          remaining_layers
-          repo_config
-          result
-          pull_request
-          synthesized_config
-          work_manifest
-        >>= function
-        | Ok cid -> Abb.Future.return (Ok cid)
-        | Error _ -> Abb.Future.return (Error `Error))
+        let module V1 = Terrat_base_repo_config_v1 in
+        let module N = V1.Notifications in
+        let module R2 = Terrat_api_components.Work_manifest_tf_operation_result2 in
+        let module Wm = Terrat_work_manifest3 in
+        let post_classic () =
+          Result.Publisher3.post_comment
+            request_id
+            account_status
+            config
+            client
+            db
+            is_layered_run
+            remaining_layers
+            repo_config
+            result
+            pull_request
+            synthesized_config
+            work_manifest
+          >>= function
+          | Ok cid -> Abb.Future.return (Ok cid)
+          | Error _ -> Abb.Future.return (Error `Error)
+        in
+        let { N.summary = { N.Summary.enabled; mode }; _ } = V1.notifications repo_config in
+        let unified =
+          enabled
+          &&
+          match mode with
+          | N.Summary.Mode.Pull_request -> true
+          | N.Summary.Mode.Header -> false
+        in
+        if not unified then post_classic ()
+        else
+          (* The unified summary comment replaces the per work manifest result
+             comment.  Gates and access control denials have no other surface,
+             so results carrying them still post the classic comment. *)
+          Terrat_vcs_github_comment_unified.mark_dirty ~request_id db work_manifest.Wm.id
+          >>= function
+          | Ok () -> (
+              match (result.R2.gates, work_manifest.Wm.denied_dirspaces) with
+              | (None | Some []), [] -> Abb.Future.return (Ok ())
+              | _, _ -> post_classic ())
+          | Error `Error ->
+              (* If the refresh cannot be tracked, fall back to the classic
+                 comment rather than losing the output entirely. *)
+              post_classic ())
     | Msg.Tier_check checks ->
         let module C = Terrat_tier.Check in
         let { C.tier_name; users_per_month; runs_per_month } = checks in
@@ -4154,6 +4183,12 @@ module Comment = struct
              "WORK_MANIFEST_RUN_FAILED"
              Tmpl.work_manifest_run_failed
              kv
+
+  let drain_unified_comment ~request_id config storage work_manifest_id =
+    Terrat_vcs_github_comment_unified.drain ~request_id config storage work_manifest_id
+
+  let mark_unified_comment_dirty ~request_id db work_manifest_id =
+    Terrat_vcs_github_comment_unified.mark_dirty_if_tracked ~request_id db work_manifest_id
 end
 
 module Repo_config = struct
@@ -4302,7 +4337,7 @@ module Repo_config = struct
              checks -> Abb.Future.return (Error (`Premium_feature_err `Require_completed_reviews))
     | {
      V1.View.notifications =
-       { V1.Notifications.summary = { V1.Notifications.Summary.enabled = true }; _ };
+       { V1.Notifications.summary = { V1.Notifications.Summary.enabled = true; _ }; _ };
      _;
     } -> Abb.Future.return (Error (`Premium_feature_err `Notifications_summary))
     | _ -> Abb.Future.return (Ok (provenance, final_repo_config))

--- a/code/src/terrat_vcs_service_gitlab/terrat_vcs_service_gitlab_provider.ml
+++ b/code/src/terrat_vcs_service_gitlab/terrat_vcs_service_gitlab_provider.ml
@@ -4041,6 +4041,10 @@ module Comment = struct
              "WORK_MANIFEST_RUN_FAILED"
              Tmpl.work_manifest_run_failed
              kv
+
+  (* The unified summary comment is not implemented for GitLab yet. *)
+  let drain_unified_comment ~request_id:_ _config _storage _work_manifest_id = Abb.Future.return ()
+  let mark_unified_comment_dirty ~request_id:_ _db _work_manifest_id = Abb.Future.return (Ok ())
 end
 
 module Repo_config = struct
@@ -4189,7 +4193,7 @@ module Repo_config = struct
              checks -> Abb.Future.return (Error (`Premium_feature_err `Require_completed_reviews))
     | {
      V1.View.notifications =
-       { V1.Notifications.summary = { V1.Notifications.Summary.enabled = true }; _ };
+       { V1.Notifications.summary = { V1.Notifications.Summary.enabled = true; _ }; _ };
      _;
     } -> Abb.Future.return (Error (`Premium_feature_err `Notifications_summary))
     | _ -> Abb.Future.return (Ok (provenance, final_repo_config))

--- a/code/tests/terrat_base_repo_config_v1/test.ml
+++ b/code/tests/terrat_base_repo_config_v1/test.ml
@@ -65,12 +65,76 @@ let test_to_version_1_round_trip =
           | _ -> failwith "Round-trip to Version_1 did not produce Engine_stategraph")
       | Error _ -> failwith "of_version_1_json failed in round-trip setup")
 
+let test_notifications_summary_mode_pull_request =
+  Oth.test ~name:"of_version_1_json: notifications summary mode pull_request" (fun _ ->
+      let module Sum = V1.Notifications.Summary in
+      let json =
+        `Assoc
+          [
+            ( "notifications",
+              `Assoc
+                [
+                  ("summary", `Assoc [ ("enabled", `Bool true); ("mode", `String "pull_request") ]);
+                ] );
+          ]
+      in
+      match V1.of_version_1_json json with
+      | Ok cfg -> (
+          let { V1.Notifications.summary; _ } = V1.notifications cfg in
+          match summary with
+          | { Sum.enabled = true; mode = Sum.Mode.Pull_request } -> ()
+          | _ -> failwith "Expected summary enabled=true with mode=Pull_request")
+      | Error _ -> failwith "of_version_1_json failed on notifications summary pull_request config")
+
+let test_notifications_summary_mode_default =
+  Oth.test ~name:"of_version_1_json: notifications summary mode defaults to header" (fun _ ->
+      let module Sum = V1.Notifications.Summary in
+      let json =
+        `Assoc [ ("notifications", `Assoc [ ("summary", `Assoc [ ("enabled", `Bool true) ]) ]) ]
+      in
+      match V1.of_version_1_json json with
+      | Ok cfg -> (
+          let { V1.Notifications.summary; _ } = V1.notifications cfg in
+          match summary with
+          | { Sum.enabled = true; mode = Sum.Mode.Header } -> ()
+          | _ -> failwith "Expected summary enabled=true with default mode=Header")
+      | Error _ -> failwith "of_version_1_json failed on notifications summary default mode config")
+
+let test_notifications_summary_mode_round_trip =
+  Oth.test ~name:"to_version_1: notifications summary mode round-trips" (fun _ ->
+      let module Sn = Repo.Notifications_summary in
+      let round_trip mode_str expected =
+        let json =
+          `Assoc
+            [
+              ( "notifications",
+                `Assoc
+                  [ ("summary", `Assoc [ ("enabled", `Bool true); ("mode", `String mode_str) ]) ] );
+            ]
+        in
+        match V1.of_version_1_json json with
+        | Ok cfg -> (
+            let v1 = V1.to_version_1 cfg in
+            match v1.Repo.Version_1.notifications with
+            | Some { Repo.Notifications.summary = Some { Sn.enabled = true; mode }; _ } ->
+                if mode <> expected then
+                  failwith
+                    (Printf.sprintf "Round-trip of mode %s produced a different mode" mode_str)
+            | _ -> failwith "Round-trip to Version_1 did not produce a notifications summary")
+        | Error _ -> failwith "of_version_1_json failed in notifications summary round-trip setup"
+      in
+      round_trip "pull_request" `Pull_request;
+      round_trip "header" `Header)
+
 let test =
   Oth.parallel
     [
       test_of_version_1_json_minimal;
       test_of_version_1_json_with_version;
       test_to_version_1_round_trip;
+      test_notifications_summary_mode_pull_request;
+      test_notifications_summary_mode_default;
+      test_notifications_summary_mode_round_trip;
     ]
 
 let () =

--- a/code/tests/terrat_repo_config/test.ml
+++ b/code/tests/terrat_repo_config/test.ml
@@ -91,6 +91,49 @@ let test_engine_chain_unknown_falls_to_other =
       | Error _ ->
           failwith "Expected Engine_other to accept unknown engine names; got Error instead")
 
+module Ns = Terrat_repo_config.Notifications_summary
+
+let test_notifications_summary_pull_request_round_trip =
+  Oth.test ~name:"Notifications_summary: mode pull_request round-trip" (fun _ ->
+      let json = `Assoc [ ("enabled", `Bool true); ("mode", `String "pull_request") ] in
+      match Ns.of_yojson json with
+      | Ok t -> (
+          assert (t.Ns.enabled = true);
+          assert (t.Ns.mode = `Pull_request);
+          let round_tripped = Ns.to_yojson t in
+          match Ns.of_yojson round_tripped with
+          | Ok t' -> assert (t'.Ns.mode = `Pull_request)
+          | Error msg -> failwith msg)
+      | Error msg -> failwith msg)
+
+let test_notifications_summary_header_round_trip =
+  Oth.test ~name:"Notifications_summary: mode header round-trip" (fun _ ->
+      let json = `Assoc [ ("enabled", `Bool true); ("mode", `String "header") ] in
+      match Ns.of_yojson json with
+      | Ok t -> (
+          assert (t.Ns.mode = `Header);
+          let round_tripped = Ns.to_yojson t in
+          match Ns.of_yojson round_tripped with
+          | Ok t' -> assert (t'.Ns.mode = `Header)
+          | Error msg -> failwith msg)
+      | Error msg -> failwith msg)
+
+let test_notifications_summary_mode_default =
+  Oth.test ~name:"Notifications_summary: mode omitted defaults to header" (fun _ ->
+      let json = `Assoc [ ("enabled", `Bool true) ] in
+      match Ns.of_yojson json with
+      | Ok t ->
+          assert (t.Ns.enabled = true);
+          assert (t.Ns.mode = `Header)
+      | Error msg -> failwith msg)
+
+let test_notifications_summary_rejects_unknown_mode =
+  Oth.test ~name:"Notifications_summary: unknown mode rejected" (fun _ ->
+      let json = `Assoc [ ("enabled", `Bool true); ("mode", `String "sidebar") ] in
+      match Ns.of_yojson json with
+      | Ok _ -> failwith "Expected unknown mode to be rejected, but it was accepted"
+      | Error _ -> ())
+
 let test =
   Oth.parallel
     [
@@ -102,6 +145,10 @@ let test =
       test_engine_chain_to_yojson_dispatches;
       test_stategraph_with_tf_fields_round_trip;
       test_engine_chain_unknown_falls_to_other;
+      test_notifications_summary_pull_request_round_trip;
+      test_notifications_summary_header_round_trip;
+      test_notifications_summary_mode_default;
+      test_notifications_summary_rejects_unknown_mode;
     ]
 
 let () =

--- a/code/tests/terrat_vcs_comment/test.ml
+++ b/code/tests/terrat_vcs_comment/test.ml
@@ -713,6 +713,401 @@ let test_minimize_strategy =
       multiple_mixed;
     ]
 
+(* Scripted-queue harness for Terrat_vcs_comment_unified, analogous to
+   [Eh]/[H] above but with the unified comment command set. *)
+module Ehu = struct
+  type el = {
+    dirspace : Terrat_dirspace.t;
+    status : Terrat_vcs_comment_unified.Status.t;
+    has_changes : bool;
+    size : int;
+  }
+  [@@deriving ord, show]
+
+  type comment_id = int [@@deriving ord, show]
+
+  type t =
+    | Query_els of (el list, [ `Error ]) result
+    | Query_comment_id of (comment_id option, [ `Error ]) result
+    | Update_comment of comment_id * string * (unit, [ `Not_found | `Error ]) result
+    | Post_comment of string * (comment_id, [ `Error ]) result
+    | Upsert_comment_id of comment_id * (unit, [ `Error ]) result
+  [@@deriving show]
+
+  type commands = t list [@@deriving show]
+end
+
+module Hu = struct
+  module U = Terrat_vcs_comment_unified
+
+  type t = Ehu.commands ref
+  type el = Ehu.el [@@deriving ord, show]
+  type comment_id = Ehu.comment_id [@@deriving ord, show]
+
+  let table_row_cost = 2
+
+  let query_els t =
+    match !t with
+    | Ehu.Query_els cmd_result :: rest ->
+        t := rest;
+        let abb_result = Abb.Future.return cmd_result in
+        (abb_result : ('a, [ `Error ]) result Abb.Future.t :> ('a, [> `Error ]) result Abb.Future.t)
+    | es ->
+        Printf.printf "\n\tQUERY ELS LOG: %s%!\n" (Ehu.show_commands es);
+        assert false
+
+  let query_comment_id t =
+    match !t with
+    | Ehu.Query_comment_id cmd_result :: rest ->
+        t := rest;
+        let abb_result = Abb.Future.return cmd_result in
+        (abb_result : ('a, [ `Error ]) result Abb.Future.t :> ('a, [> `Error ]) result Abb.Future.t)
+    | es ->
+        Printf.printf "\n\tQUERY COMMENT_ID LOG: %s%!\n" (Ehu.show_commands es);
+        assert false
+
+  let tier_label = function
+    | U.Tier.Details n -> Printf.sprintf "details(%d)" n
+    | U.Tier.Table -> "table"
+    | U.Tier.Truncated n -> Printf.sprintf "truncated(%d)" n
+
+  (* Pure renderer.  The body records the tier and the element order so tests
+     can assert on both, and its length is a deterministic function of the
+     tier and the element sizes so tests can force tier selection via [size]
+     and [max_comment_length]. *)
+  let render _ tier els =
+    let shown =
+      match tier with
+      | U.Tier.Details _ | U.Tier.Table -> els
+      | U.Tier.Truncated n -> CCList.take n els
+    in
+    let order =
+      CCString.concat "," (CCList.map (fun el -> el.Ehu.dirspace.Terrat_dirspace.dir) shown)
+    in
+    let content_length =
+      match tier with
+      | U.Tier.Details n ->
+          CCList.fold_left (fun acc el -> acc + el.Ehu.size) 0 (CCList.take n els)
+          + (CCList.length els * table_row_cost)
+      | U.Tier.Table -> CCList.length els * table_row_cost
+      | U.Tier.Truncated _ -> CCList.length shown * table_row_cost
+    in
+    Printf.sprintf "%s|%s|%s" (tier_label tier) order (CCString.make content_length 'x')
+
+  let update_comment t cid body =
+    match !t with
+    | Ehu.Update_comment (cid2, body2, cmd_result) :: rest when cid = cid2 && body = body2 ->
+        t := rest;
+        let abb_result = Abb.Future.return cmd_result in
+        (abb_result
+          : ('a, [ `Not_found | `Error ]) result Abb.Future.t
+          :> ('a, [> `Not_found | `Error ]) result Abb.Future.t)
+    | es ->
+        Printf.printf "\n\tUPDATE COMMENT INPUT: %d %s%!\n" cid body;
+        Printf.printf "\n\tUPDATE COMMENT LOG: %s%!\n" (Ehu.show_commands es);
+        assert false
+
+  let post_comment t body =
+    match !t with
+    | Ehu.Post_comment (body2, cmd_result) :: rest when body = body2 ->
+        t := rest;
+        let abb_result = Abb.Future.return cmd_result in
+        (abb_result : ('a, [ `Error ]) result Abb.Future.t :> ('a, [> `Error ]) result Abb.Future.t)
+    | es ->
+        Printf.printf "\n\tPOST COMMENT INPUT: %s%!\n" body;
+        Printf.printf "\n\tPOST COMMENT LOG: %s%!\n" (Ehu.show_commands es);
+        assert false
+
+  let upsert_comment_id t cid =
+    match !t with
+    | Ehu.Upsert_comment_id (cid2, cmd_result) :: rest when cid = cid2 ->
+        t := rest;
+        let abb_result = Abb.Future.return cmd_result in
+        (abb_result : ('a, [ `Error ]) result Abb.Future.t :> ('a, [> `Error ]) result Abb.Future.t)
+    | es ->
+        Printf.printf "\n\tUPSERT INPUT: %d%!\n" cid;
+        Printf.printf "\n\tUPSERT LOG: %s%!\n" (Ehu.show_commands es);
+        assert false
+
+  let dirspace el = el.Ehu.dirspace
+  let status el = el.Ehu.status
+  let has_changes el = el.Ehu.has_changes
+  let max_comment_length = 100
+end
+
+module Shared_unified = struct
+  let create_el dir status has_changes size =
+    let module D = Terrat_dirspace in
+    { Ehu.dirspace = D.{ dir; workspace = "default" }; status; has_changes; size }
+
+  (* [render] is pure so the expected body is just the renderer applied to the
+     expected tier and the expected sorted order. *)
+  let expected_body tier els = Hu.render (ref []) tier els
+end
+
+module Make_unified_wrapper = struct
+  let run t =
+    let open Abb.Future.Infix_monad in
+    let module Cm = Terrat_vcs_comment_unified.Make (Hu) in
+    Cm.run t
+    >>= function
+    | Ok () -> (
+        match !t with
+        | [] -> Abb.Future.return (Ok ())
+        | es ->
+            Printf.printf "\n\tT: %s%!\n" (Ehu.show_commands es);
+            assert false)
+    | Error e -> Abb.Future.return (Error e)
+end
+
+let test_unified_basic =
+  let empty_els =
+    Oth_abb.test
+      ~desc:"No elements means the comment is left untouched and nothing else is called"
+      ~name:"[Unified] Empty elements"
+      (fun () ->
+        let open Abb.Future.Infix_monad in
+        let t = ref [ Ehu.Query_els (Ok []) ] in
+        Make_unified_wrapper.run t
+        >>= function
+        | Ok () -> Abb.Future.return ()
+        | Error _ -> assert false)
+  in
+  let first_post =
+    Oth_abb.test
+      ~desc:"No tracked comment yet: post a fresh comment and record its id"
+      ~name:"[Unified] First publish posts and upserts"
+      (fun () ->
+        let open Abb.Future.Infix_monad in
+        let module U = Terrat_vcs_comment_unified in
+        let el1 = Shared_unified.create_el "A" U.Status.Planned true 10 in
+        let els = [ el1 ] in
+        let body = Shared_unified.expected_body (U.Tier.Details 1) els in
+        let t =
+          ref
+            [
+              Ehu.Query_els (Ok els);
+              Ehu.Query_comment_id (Ok None);
+              Ehu.Post_comment (body, Ok 1);
+              Ehu.Upsert_comment_id (1, Ok ());
+            ]
+        in
+        Make_unified_wrapper.run t
+        >>= function
+        | Ok () -> Abb.Future.return ()
+        | Error _ -> assert false)
+  in
+  let existing_update =
+    Oth_abb.test
+      ~desc:"A tracked comment is updated in place with no post or upsert"
+      ~name:"[Unified] Existing comment is updated"
+      (fun () ->
+        let open Abb.Future.Infix_monad in
+        let module U = Terrat_vcs_comment_unified in
+        let el1 = Shared_unified.create_el "A" U.Status.Planned true 10 in
+        let els = [ el1 ] in
+        let body = Shared_unified.expected_body (U.Tier.Details 1) els in
+        let t =
+          ref
+            [
+              Ehu.Query_els (Ok els);
+              Ehu.Query_comment_id (Ok (Some 42));
+              Ehu.Update_comment (42, body, Ok ());
+            ]
+        in
+        Make_unified_wrapper.run t
+        >>= function
+        | Ok () -> Abb.Future.return ()
+        | Error _ -> assert false)
+  in
+  Oth_abb.parallel [ empty_els; first_post; existing_update ]
+
+let test_unified_errors =
+  let update_not_found =
+    Oth_abb.test
+      ~desc:"A tracked comment that was deleted falls back to posting a fresh comment"
+      ~name:"[Unified] Update not found falls back to post"
+      (fun () ->
+        let open Abb.Future.Infix_monad in
+        let module U = Terrat_vcs_comment_unified in
+        let el1 = Shared_unified.create_el "A" U.Status.Planned true 10 in
+        let els = [ el1 ] in
+        let body = Shared_unified.expected_body (U.Tier.Details 1) els in
+        let t =
+          ref
+            [
+              Ehu.Query_els (Ok els);
+              Ehu.Query_comment_id (Ok (Some 42));
+              Ehu.Update_comment (42, body, Error `Not_found);
+              Ehu.Post_comment (body, Ok 43);
+              Ehu.Upsert_comment_id (43, Ok ());
+            ]
+        in
+        Make_unified_wrapper.run t
+        >>= function
+        | Ok () -> Abb.Future.return ()
+        | Error _ -> assert false)
+  in
+  let update_error =
+    Oth_abb.test
+      ~desc:"An error during update_comment is propagated"
+      ~name:"[Unified] Update error is propagated"
+      (fun () ->
+        let open Abb.Future.Infix_monad in
+        let module U = Terrat_vcs_comment_unified in
+        let el1 = Shared_unified.create_el "A" U.Status.Planned true 10 in
+        let els = [ el1 ] in
+        let body = Shared_unified.expected_body (U.Tier.Details 1) els in
+        let t =
+          ref
+            [
+              Ehu.Query_els (Ok els);
+              Ehu.Query_comment_id (Ok (Some 42));
+              Ehu.Update_comment (42, body, Error `Error);
+            ]
+        in
+        Make_unified_wrapper.run t
+        >>= function
+        | Ok _ -> assert false
+        | Error `Error ->
+            assert (!t = []);
+            Abb.Future.return ()
+        | Error _ -> assert false)
+  in
+  Oth_abb.parallel [ update_not_found; update_error ]
+
+let test_unified_sorting =
+  let mixed_order =
+    Oth_abb.test
+      ~desc:
+        "Elements arrive at render sorted by status rank, then has_changes (changes first), then \
+         dirspace, regardless of input order"
+      ~name:"[Unified] Sorting"
+      (fun () ->
+        let open Abb.Future.Infix_monad in
+        let module U = Terrat_vcs_comment_unified in
+        let el_applied = Shared_unified.create_el "a" U.Status.Applied false 5 in
+        let el_failed = Shared_unified.create_el "z" U.Status.Failed true 5 in
+        let el_planned_changes = Shared_unified.create_el "m" U.Status.Planned true 5 in
+        let el_planned_no_changes = Shared_unified.create_el "b" U.Status.Planned false 5 in
+        let el_pending = Shared_unified.create_el "q" U.Status.Pending false 5 in
+        let els =
+          [ el_applied; el_planned_no_changes; el_pending; el_failed; el_planned_changes ]
+        in
+        (* Failed first, then planned with changes before planned without
+           (despite "b" < "m"), then pending, then applied. *)
+        let sorted =
+          [ el_failed; el_planned_changes; el_planned_no_changes; el_pending; el_applied ]
+        in
+        let body = Shared_unified.expected_body (U.Tier.Details 5) sorted in
+        let t =
+          ref
+            [
+              Ehu.Query_els (Ok els);
+              Ehu.Query_comment_id (Ok None);
+              Ehu.Post_comment (body, Ok 1);
+              Ehu.Upsert_comment_id (1, Ok ());
+            ]
+        in
+        Make_unified_wrapper.run t
+        >>= function
+        | Ok () -> Abb.Future.return ()
+        | Error _ -> assert false)
+  in
+  Oth_abb.parallel [ mixed_order ]
+
+let test_unified_tiers =
+  let table_tier =
+    Oth_abb.test
+      ~desc:"Oversized details force degradation to the table tier"
+      ~name:"[Unified] Tier degradation to table"
+      (fun () ->
+        let open Abb.Future.Infix_monad in
+        let module U = Terrat_vcs_comment_unified in
+        let el1 = Shared_unified.create_el "a" U.Status.Planned true 40 in
+        let el2 = Shared_unified.create_el "b" U.Status.Planned true 40 in
+        let el3 = Shared_unified.create_el "c" U.Status.Planned true 40 in
+        let els = [ el1; el2; el3 ] in
+        (* Details 3 renders 3 * 40 + 3 * table_row_cost > max_comment_length,
+           so the table tier is chosen. *)
+        let body = Shared_unified.expected_body U.Tier.Table els in
+        let t =
+          ref
+            [
+              Ehu.Query_els (Ok els);
+              Ehu.Query_comment_id (Ok None);
+              Ehu.Post_comment (body, Ok 1);
+              Ehu.Upsert_comment_id (1, Ok ());
+            ]
+        in
+        Make_unified_wrapper.run t
+        >>= function
+        | Ok () -> Abb.Future.return ()
+        | Error _ -> assert false)
+  in
+  let details_five_tier =
+    Oth_abb.test
+      ~desc:"More than 5 elements that do not all fit degrade to details for the first 5"
+      ~name:"[Unified] Tier degradation to details 5"
+      (fun () ->
+        let open Abb.Future.Infix_monad in
+        let module U = Terrat_vcs_comment_unified in
+        let el1 = Shared_unified.create_el "a" U.Status.Planned true 10 in
+        let el2 = Shared_unified.create_el "b" U.Status.Planned true 10 in
+        let el3 = Shared_unified.create_el "c" U.Status.Planned true 10 in
+        let el4 = Shared_unified.create_el "d" U.Status.Planned true 10 in
+        let el5 = Shared_unified.create_el "e" U.Status.Planned true 10 in
+        let el6 = Shared_unified.create_el "f" U.Status.Planned true 60 in
+        let els = [ el1; el2; el3; el4; el5; el6 ] in
+        (* Details 6 includes the oversized 6th element and does not fit;
+           Details 5 drops its details and does. *)
+        let body = Shared_unified.expected_body (U.Tier.Details 5) els in
+        let t =
+          ref
+            [
+              Ehu.Query_els (Ok els);
+              Ehu.Query_comment_id (Ok None);
+              Ehu.Post_comment (body, Ok 1);
+              Ehu.Upsert_comment_id (1, Ok ());
+            ]
+        in
+        Make_unified_wrapper.run t
+        >>= function
+        | Ok () -> Abb.Future.return ()
+        | Error _ -> assert false)
+  in
+  let truncated_tier =
+    Oth_abb.test
+      ~desc:
+        "When even the full table does not fit, degradation ends at the unconditional truncated \
+         tier"
+      ~name:"[Unified] Tier degradation to truncated"
+      (fun () ->
+        let open Abb.Future.Infix_monad in
+        let module U = Terrat_vcs_comment_unified in
+        let els =
+          CCList.init 60 (fun i ->
+              Shared_unified.create_el (Printf.sprintf "d%02d" i) U.Status.Planned true 0)
+        in
+        (* 60 table rows exceed max_comment_length, as do the first 50, so the
+           final Truncated 10 tier is used. *)
+        let body = Shared_unified.expected_body (U.Tier.Truncated 10) els in
+        let t =
+          ref
+            [
+              Ehu.Query_els (Ok els);
+              Ehu.Query_comment_id (Ok None);
+              Ehu.Post_comment (body, Ok 1);
+              Ehu.Upsert_comment_id (1, Ok ());
+            ]
+        in
+        Make_unified_wrapper.run t
+        >>= function
+        | Ok () -> Abb.Future.return ()
+        | Error _ -> assert false)
+  in
+  Oth_abb.parallel [ table_tier; details_five_tier; truncated_tier ]
+
 let test =
   Oth_abb.(
     to_sync_test
@@ -723,6 +1118,10 @@ let test =
            test_append_strategy;
            test_delete_strategy;
            test_minimize_strategy;
+           test_unified_basic;
+           test_unified_errors;
+           test_unified_sorting;
+           test_unified_tiers;
          ]))
 
 let () =

--- a/docs/src/content/docs/editions.mdx
+++ b/docs/src/content/docs/editions.mdx
@@ -31,7 +31,7 @@ Terrateam ships in two editions: the **Open Source Edition** (MPL-2.0, free) and
 | [Gatekeeper](/governance/gatekeeper) (manual approval gates with tokens) | ❌ | ✅ |
 | [Centralized Configuration](/governance/centralized-config) (defaults/overrides across repos) | ❌ | ✅ |
 | [API Access Tokens](/reference/api/access-tokens) (`/api/v1/{vcs}/access-token`) | ❌ | ✅ |
-| [Comment summary header](/reference/configuration/notifications) (`notifications.summary`) | ❌ | ✅ |
+| [Comment summary header and unified PR summary comment](/reference/configuration/notifications) (`notifications.summary`) | ❌ | ✅ |
 | Self-hostable | ✅ | ✅ (Enterprise license) |
 | License | MPL-2.0 | Commercial |
 

--- a/docs/src/content/docs/reference/configuration/notifications.mdx
+++ b/docs/src/content/docs/reference/configuration/notifications.mdx
@@ -36,6 +36,7 @@ The summary header is an [Enterprise](/editions) feature. Enabling it on the Ope
 | Key | Type | Description |
 | --- | --- | --- |
 | `enabled` | boolean | When `true`, each plan and apply comment starts with a summary header: a one-line rollup and a table of the dirspaces (directory and workspace combinations) executed in that comment, with their result and, for plans, whether there are changes. This lets reviewers see what a comment covers without expanding the full output. Default is `false`. |
+| `mode` | string | How the summary is presented. Values are `header` (the per-comment summary header described above) or `pull_request` (a single unified summary comment maintained for the whole pull request). Default is `header`. |
 
 The summary header is rendered above the collapsed plan/apply output. Enable it (Enterprise only):
 
@@ -44,6 +45,33 @@ notifications:
   summary:
     enabled: true
 ```
+
+#### Pull Request Mode
+
+With `mode: pull_request`, Terrateam maintains one summary comment per pull request instead of a header on every plan and apply comment. The comment is created when the first result arrives and updated in place as each subsequent run finishes, so reviewers always have a single up-to-date view of the pull request.
+
+The unified comment contains a table with one row per dirspace (directory and workspace combination):
+
+- **Status**: `Pending`, `Planned`, `Applied`, or `Failed`.
+- **Change counts**: `Created`, `Updated`, `Replaced`, and `Deleted`, parsed from the plan/apply output. `Replaced` is not yet populated and shows `-`.
+- **Link**: a per-dirspace link to the Terrateam console.
+
+A totals row sums the change counts across all dirspaces. Rows are sorted with failures first, then dirspaces with changes.
+
+In this mode the regular per-run plan and apply output comments are not posted; the full output is available in the Terrateam console via the links in the table. The exception is results carrying gate approvals or access control denials, which still post their own comment.
+
+If the table is too large to fit in a single comment, it is truncated to the top rows with a link to the console for the full list.
+
+Enable it (Enterprise only):
+
+```yaml
+notifications:
+  summary:
+    enabled: true
+    mode: pull_request
+```
+
+Both `mode` values require `enabled: true`, which is an [Enterprise](/editions) feature.
 
 ## Examples
 ### Multiple Comment Strategies for Diferent Dirspaces


### PR DESCRIPTION
## Split plan (2026-08-03)

This draft is now being treated as a live-validated proof-of-work/reference branch, not the final review shape. The replacement draft stack is #1471 → #1472 → #1473. Before review/merge, split the work into:

- #1471: standalone prerequisite PR for the `abb_curl` PATCH-with-body fix;
- #1472: migration-safety PR for #1399 (`workflow_step_outputs_dirspace_idx` as a concurrent, non-transactional migration);
- #1473: rebuilt/rebased core unified GitHub summary-comment PR containing the vertical feature work.

The paired runner PR remains terrateamio/action#618 and can land after the server-side support; until then the unified comment renders missing resource counts as `-`.

## Description

Adds `notifications.summary.mode` (`header` | `pull_request`). In `pull_request` mode Terrateam maintains a single **unified summary comment per pull request**, updated in place as each work manifest result lands, instead of one comment per work manifest. Requires `notifications.summary.enabled: true` (Enterprise-gated, same gate as the existing summary header).

**How it works**
- The result transaction only bumps a `dirty` counter on a new `github_unified_comments` row (committed atomically with the stored results).
- After commit, the evaluator forks a drain that serializes on an advisory lock, recomputes every dirspace's state from the database (anchored on the PR's current sha incl. the latest merged sha, filtered through PR unlocks), renders a sorted status table, and PATCHes the tracked comment (posting anew if a user deleted it). A compare-and-swap on `dirty` retries when new results land mid-publish, so concurrent work manifests converge to a single comment.
- Results carrying gates or access-control denials still post the classic per-WM comment (they have no other surface). GitLab is stubbed pending its comment-tracking tables.

**Change counts (Created / Updated / Replaced / Deleted)**
Come **solely** from the exact `resource_summary` the runner computes from `terraform show -json` — paired change: **terrateamio/action#618**. There is **no text parsing**: a runner/engine that doesn't emit them leaves the columns blank (`-`) rather than reporting a guessed number.

Rollout is decoupled: this PR is safe to merge **before** the runner change — until the `v1` action rebuild carries `resource_summary`, the count columns simply render `-`. Server-first is the recommended order.

**Also in this PR — abb_curl PATCH fix**
The unified comment updates in place via HTTP PATCH — the first PATCH-with-body caller in the tree. `abb_curl` set `CURLOPT_POSTFIELDSIZE` via a read callback but never enabled POST/upload mode for `PATCH`, so the body went out empty and GitHub returned 422. Fixed by enabling POST send-mode when a body is present (the verb still comes from `CUSTOMREQUEST`). Scoped to `PATCH`; `Githubc2_issues.Update_comment` is the only PATCH/DELETE/custom-with-body caller in the codebase, so nothing relied on the old behavior and GET/PUT/POST are untouched.

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (explain):

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/terrateamio/terrateam/blob/main/CONTRIBUTING.md)
- [x] The pull request title follows this format:
      `ISSUE_NUMBER ACTION_TYPE Short description` (e.g., `123 ADD Feature description`)
- [x] I have added tests and documentation (if applicable)
- [x] My changes generate no new warnings/errors and do not break existing functionality

## Additional context (optional)

Paired runner PR: **terrateamio/action#618** (emits `resource_summary`).

Validated live end-to-end on a dev EE image against real PRs: multi-dirspace consolidation, sorting, in-place update on push (stale rows drop / new appear), apply → Applied with counts retained, delete-comment → 404 repost, `mode: header` parity (classic comment, no unified row), `> 20` dirspaces → table-only, `batch_runs` concurrency → exactly one comment, OSS rejection of the EE feature, and structured counts from terraform / tofu / terragrunt / stategraph (including a real Replace). Full checklist and open items: #1214 (implementation-tracker comment).

Part of #1214 (tracking parent; follow-ups tracked as sub-issues there)