### PR TITLE
#1406 FIX Add missing security response headers and session cookie SameSite

### DIFF
--- a/code/src/brtl_mw_session/brtl_mw_session.ml
+++ b/code/src/brtl_mw_session/brtl_mw_session.ml
@@ -76,6 +76,11 @@ let store_cookie config cookie value v ctx =
       (cookie.Config.Cookie.name, cookie_id)
   in
   let cookie_header, cookie_value = Cohttp.Cookie.Set_cookie_hdr.serialize cookie in
+  (* Cohttp's Set_cookie_hdr has no SameSite field, so the attribute is appended
+     after serialisation.  Lax rather than Strict: the OAuth callback returns via
+     a cross-site top-level navigation, which Strict would strip the cookie from,
+     breaking sign-in. *)
+  let cookie_value = cookie_value ^ "; SameSite=Lax" in
   ctx
   |> Brtl_ctx.response
   |> Brtl_rspnc.add_header cookie_header cookie_value

--- a/docker/terrat/nginx.conf.template
+++ b/docker/terrat/nginx.conf.template
@@ -46,6 +46,14 @@ http {
         access_log   ${TERRAT_ACCESS_LOG};
         server_tokens off;
 
+        # nginx replaces, rather than merges, inherited add_header directives as
+        # soon as a location declares its own, so these are repeated in each
+        # location that sets any header of its own.
+        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+        add_header X-Frame-Options "DENY" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+
         location / {
 
             set $cspNonce '$request_id';
@@ -64,6 +72,10 @@ http {
             index index.html index.htm;
             try_files $uri $uri/ /index.html =404;
             add_header Content-Security-Policy "default-src 'self'; img-src 'self' https://avatars.githubusercontent.com https://secure.gravatar.com https://www.redditstatic.com https://alb.reddit.com; script-src 'self' 'nonce-$cspNonce' https://*.posthog.com https://www.redditstatic.com https://js.stripe.com; style-src 'self' 'nonce-$cspNonce'; object-src 'none'; connect-src 'self' https://*.posthog.com https://o4509570379677696.ingest.de.sentry.io https://api.web3forms.com https://alb.reddit.com https://pixel-config.reddit.com https://conversions-config.reddit.com https://www.redditstatic.com; font-src 'self'; worker-src 'self' blob:; frame-src https://js.stripe.com; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; manifest-src 'self'; media-src 'none'; upgrade-insecure-requests;";
+            add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+            add_header X-Frame-Options "DENY" always;
+            add_header X-Content-Type-Options "nosniff" always;
+            add_header Referrer-Policy "strict-origin-when-cross-origin" always;
         }
 
         location /api {
@@ -86,6 +98,14 @@ http {
 
             # Add a long timeout to match the timeouts on the server side.
             proxy_read_timeout 120;
+
+            # API responses carry organisation-scoped data and must not be
+            # stored by browsers or intermediary caches.
+            add_header Cache-Control "no-store" always;
+            add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+            add_header X-Frame-Options "DENY" always;
+            add_header X-Content-Type-Options "nosniff" always;
+            add_header Referrer-Policy "strict-origin-when-cross-origin" always;
         }
 
         # Turn off rate limit for health checks


### PR DESCRIPTION
## Description

Fixes #1406.

Adds the security response headers flagged by the Q3 2025 penetration test (TER-004 `Strict-Transport-Security`, TER-005 `X-Frame-Options`, TER-006 `Cache-Control`) and sets `SameSite` on the session cookie (TER-003).

`add_header` was previously declared only inside `location /`. nginx replaces, rather than merges, inherited `add_header` directives once a location declares its own, so `/api` responses carried no security headers at all — not even the CSP. The headers are therefore repeated per-location, with a comment recording why.

`Cohttp.Cookie.Set_cookie_hdr` has no `SameSite` field, so the attribute is appended after `serialize`. `Lax` rather than `Strict` is deliberate: the GitHub OAuth callback returns via a cross-site top-level navigation, which `Strict` would strip the session cookie from, breaking sign-in.

`X-Content-Type-Options: nosniff` and `Referrer-Policy: strict-origin-when-cross-origin` are included alongside — not raised by the pentest, but trivial and they pre-empt the same class of finding next time. Happy to drop them if unwanted.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (explain):

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/terrateamio/terrateam/blob/main/CONTRIBUTING.md)
- [x] The pull request title follows this format:
      `ISSUE_NUMBER ACTION_TYPE Short description` (e.g., `123 ADD Feature description`)
- [ ] I have added tests and documentation (if applicable)
- [x] My changes generate no new warnings/errors and do not break existing functionality

## Additional context (optional)

Verified rather than assumed:

- `nginx -t` passes on the rendered template, and passes identically on the unmodified baseline (so no new syntax issues).
- Ran nginx against the rendered config: `GET /` returns HSTS, `X-Frame-Options`, `nosniff` and `Referrer-Policy` alongside the existing CSP; `GET /api/...` returns `Cache-Control: no-store` plus the security headers, and they are present even on a 5xx because of `always`.
- `dune build @code/src/brtl_mw_session/all` succeeds and produces artifacts. A deliberately introduced type error failed at the edited line, confirming the file is genuinely compiled, and the build is clean after reverting it.

TER-002 (cross-organisation task read) from the same pentest is **not** addressed here — it needs a schema change and is being handled separately.
