### PR TITLE
#1408 FIX Scope task lookups to the requesting user

### DIFF
--- a/code/src/terrat/migrations/2026-07-23-add-tasks-user-id.sql
+++ b/code/src/terrat/migrations/2026-07-23-add-tasks-user-id.sql
@@ -1,0 +1,3 @@
+alter table tasks add column user_id uuid;
+
+create index if not exists tasks_user_id_idx on tasks (user_id);

--- a/code/src/terrat/terrat_ep_tasks.ml
+++ b/code/src/terrat/terrat_ep_tasks.ml
@@ -13,15 +13,16 @@ module Sql = struct
       (* updated_at *)
       Ret.text
       /^ "select name, state, to_char(updated_at, 'YYYY-MM-DD\"T\"HH24:MI:SS\"Z\"') from tasks \
-          where id = $id"
-      /% Var.uuid "id")
+          where id = $id and user_id = $user_id"
+      /% Var.uuid "id"
+      /% Var.uuid "user_id")
 end
 
 let get storage task_id =
   Brtl_ep.run_result_json ~f:(fun ctx ->
       let open Abbs_future_combinators.Infix_result_monad in
       Terrat_session.with_session ctx
-      >>= fun _ ->
+      >>= fun user ->
       let open Abb.Future.Infix_monad in
       let id = Uuidm.to_string task_id in
       Pgsql_pool.with_conn storage ~f:(fun db ->
@@ -30,7 +31,8 @@ let get storage task_id =
             (Sql.select_task ())
             ~f:(fun name state updated_at ->
               { Terrat_api_components.Task.id; name; state; updated_at })
-            task_id)
+            task_id
+            (Terrat_user.id user))
       >>= function
       | Ok (task :: _) ->
           let body = Terrat_api_components.Task.to_yojson task |> Yojson.Safe.to_string in

--- a/code/src/terrat/terrat_migrations.ml
+++ b/code/src/terrat/terrat_migrations.ml
@@ -279,6 +279,7 @@ let migrations =
       run_sql [%blob "migrations/2026-03-19-delete-repo-tree-cache.sql"] );
     ( "extend-repo-configs-with-history",
       run_sql [%blob "migrations/2026-07-05-extend-repo-configs-with-history.sql"] );
+    ("add-tasks-user-id", run_sql [%blob "migrations/2026-07-23-add-tasks-user-id.sql"]);
   ]
 
 let run config storage = Mig.run { Migrate.config; storage; tx = () } migrations

--- a/code/src/terrat_task/terrat_task.ml
+++ b/code/src/terrat_task/terrat_task.ml
@@ -13,8 +13,9 @@ module Sql = struct
       //
       (* id *)
       Ret.uuid
-      /^ "insert into tasks (name) values ($name) returning id"
-      /% Var.text "name")
+      /^ "insert into tasks (name, user_id) values ($name, $user_id) returning id"
+      /% Var.text "name"
+      /% Var.option (Var.uuid "user_id"))
 
   let update_task () =
     Pgsql_io.Typed_sql.(
@@ -27,17 +28,18 @@ end
 type 'a t = {
   id : 'a;
   name : string;
+  user_id : Uuidm.t option;
 }
 
 type fresh = unit
 type stored = Uuidm.t
 
-let make ~name () = { id = (); name }
+let make ~name ?user_id () = { id = (); name; user_id }
 let id t = t.id
 
 let store db t =
   let open Abbs_future_combinators.Infix_result_monad in
-  Pgsql_io.Prepared_stmt.fetch db (Sql.insert_task ()) ~f:CCFun.id t.name
+  Pgsql_io.Prepared_stmt.fetch db (Sql.insert_task ()) ~f:CCFun.id t.name t.user_id
   >>= function
   | [] -> assert false
   | id :: _ -> Abb.Future.return (Ok { t with id })

--- a/code/src/terrat_task/terrat_task.mli
+++ b/code/src/terrat_task/terrat_task.mli
@@ -9,7 +9,7 @@ type run_err =
   | Pgsql_io.err
   ]
 
-val make : name:string -> unit -> fresh t
+val make : name:string -> ?user_id:Uuidm.t -> unit -> fresh t
 val id : stored t -> Uuidm.t
 val store : Pgsql_io.t -> fresh t -> (stored t, [> store_err ]) result Abb.Future.t
 val abort : Pgsql_io.t -> stored t -> (unit, [> abort_err ]) result Abb.Future.t

--- a/code/src/terrat_vcs_service_github/terrat_vcs_service_github_ep_installations.ml
+++ b/code/src/terrat_vcs_service_github/terrat_vcs_service_github_ep_installations.ml
@@ -1300,6 +1300,7 @@ module Make (S : S with type Account_id.t = int) = struct
               ~request_id:(Brtl_ctx.token ctx)
               ~config
               ~storage
+              ~user_id:(Terrat_user.id user)
               (Terrat_vcs_service_github_installation.Id.make installation_id)
             >>= function
             | Ok task ->

--- a/code/src/terrat_vcs_service_github/terrat_vcs_service_github_installation.ml
+++ b/code/src/terrat_vcs_service_github/terrat_vcs_service_github_installation.ml
@@ -132,11 +132,12 @@ let refresh_repos_task request_id config storage installation_id task =
       Logs.err (fun m -> m "INSTALLATION : %s : REFRESH_REPOS : %a" request_id Pgsql_io.pp_err err);
       Abb.Future.return ()
 
-let refresh_repos' ~request_id ~config ~storage installation_id =
+let refresh_repos' ~request_id ~config ~storage ?user_id installation_id =
   Logs.debug (fun m -> m "INSTALLATION : %s : REPO_REFRESH : %d" request_id installation_id);
   let task =
     Terrat_task.make
       ~name:(Printf.sprintf "INSTALLATION : %s : REPO_REFRESH : %d" request_id installation_id)
+      ?user_id
       ()
   in
   let open Abbs_future_combinators.Infix_result_monad in

--- a/code/src/terrat_vcs_service_github/terrat_vcs_service_github_installation.mli
+++ b/code/src/terrat_vcs_service_github/terrat_vcs_service_github_installation.mli
@@ -29,5 +29,6 @@ val refresh_repos' :
   request_id:string ->
   config:Terrat_vcs_service_github_provider.Api.Config.t ->
   storage:Terrat_storage.t ->
+  ?user_id:Uuidm.t ->
   Id.t ->
   (Terrat_task.stored Terrat_task.t, [> refresh_repos_err' ]) result Abb.Future.t


### PR DESCRIPTION
## Description

Fixes #1408.

`GET /api/v1/tasks/{id}` required an authenticated session but did not check that the session user had any relationship to the task being requested — `Terrat_ep_tasks.get` discarded the user and selected purely by id. The `tasks` table had no ownership column, so there was nothing to authorise against.

- Adds a nullable `user_id` column to `tasks`, with an index.
- Records the creating user. There is one live creation path, `Refresh.post` in `terrat_vcs_service_github_ep_installations.ml`, which already resolves a session user and calls `enforce_installation_access` before creating the task — so the write side was already scoped, and this brings the read side in line.
- `Terrat_ep_tasks.get` now returns the task only when its `user_id` matches the session user.

`user_id` is optional throughout rather than required, so the unused `refresh_repos'` in `terrat_vcs_service_github_ep_installation.ml` continues to compile unchanged.

Two decisions worth flagging for review:

- **`404` rather than `403`** when the ownership check fails. A `403` would confirm that a given task id exists, turning the endpoint into an existence oracle for other users' tasks.
- **Tasks predating the migration have a null `user_id` and are not readable.** They are all long completed and nothing polls them. The alternative — backfilling ownership by parsing the task `name` string — is fragile and was not worth it.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (explain):

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/terrateamio/terrateam/blob/main/CONTRIBUTING.md)
- [x] The pull request title follows this format:
      `ISSUE_NUMBER ACTION_TYPE Short description` (e.g., `123 ADD Feature description`)
- [ ] I have added tests and documentation (if applicable)
- [x] My changes generate no new warnings/errors and do not break existing functionality

## Additional context (optional)

Raised as TER-002 in the Q3 2025 penetration test.

Exploitability was low: task ids are `gen_random_uuid()`, no endpoint lists or enumerates them, and they are only ever returned to the caller that created the task — they are not placed in URLs or logs. The concern is that the safety came from the identifier being unguessable rather than from an enforced check, so it would have quietly stopped holding if a list endpoint were added or an id were ever deep-linked.

Formatting was applied with the pinned ocamlformat 0.29.0. The OCaml build was not run locally (the dev box ran out of disk), so this relies on CI for compilation.

Follow-up worth a separate issue: `tasks` rows are never deleted — there is no retention job or TTL, so the table grows without bound.
