### PR TITLE
#1436 FIX Use GitHub's review decision for require_completed_reviews

### DIFF
--- a/code/src/terrat_github/terrat_github.ml
+++ b/code/src/terrat_github/terrat_github.ml
@@ -133,6 +133,13 @@ type minimize_comment_err =
   ]
 [@@deriving show]
 
+type fetch_pull_request_review_decision_err =
+  [ Githubc2_abb.call_err
+  | `Graphql_err of string list
+  | `Not_found
+  ]
+[@@deriving show]
+
 type publish_reaction_err =
   [ Githubc2_abb.call_err
   | `Unprocessable_entity of Githubc2_components.Validation_error.t
@@ -548,6 +555,114 @@ let minimize_comment ~owner ~repo ~comment_id client =
           | `OK -> Abb.Future.return (Ok ())
           | `Not_found -> Abb.Future.return (Error `Not_found)))
   | `Not_found _ -> Abb.Future.return (Error `Not_found)
+
+(* [reviewDecision] is GitHub's own verdict on whether the pull request
+   satisfies the target branch's required-review rule, including CODEOWNERS
+   matching.  There is no REST equivalent, so this has to go through GraphQL.
+   The value is [null] when the branch has no rule requiring reviews at all,
+   which is why the result is an option. *)
+let fetch_pull_request_review_decision ~owner ~repo ~pull_number client =
+  Prmths.Counter.inc_one (Metrics.fn_call_total "fetch_pull_request_review_decision");
+  let open Abbs_future_combinators.Infix_result_monad in
+  let module Body = struct
+    module Variables = struct
+      type t = {
+        owner : string;
+        repo : string;
+        pull_number : int;
+      }
+      [@@deriving to_yojson]
+    end
+
+    type t = {
+      query : string;
+      variables : Variables.t;
+    }
+    [@@deriving to_yojson]
+  end in
+  let module Resp = struct
+    module Err = struct
+      type t = { message : string } [@@deriving of_yojson { strict = false }, show]
+    end
+
+    module Pull_request = struct
+      type t = { review_decision : string option [@key "reviewDecision"] [@default None] }
+      [@@deriving of_yojson { strict = false }]
+    end
+
+    module Repository = struct
+      type t = { pull_request : Pull_request.t option [@key "pullRequest"] [@default None] }
+      [@@deriving of_yojson { strict = false }]
+    end
+
+    module Data = struct
+      type t = { repository : Repository.t option [@default None] }
+      [@@deriving of_yojson { strict = false }]
+    end
+
+    type t = {
+      data : Data.t option; [@default None]
+      errors : Err.t list option; [@default None]
+    }
+    [@@deriving of_yojson { strict = false }]
+  end in
+  let create_review_decision_request url =
+    let query =
+      {|
+        query($owner: String!, $repo: String!, $pull_number: Int!) {
+            repository(owner: $owner, name: $repo) {
+                pullRequest(number: $pull_number) {
+                reviewDecision
+                }
+            }
+        }
+      |}
+    in
+    let body = { Body.query; variables = { Body.Variables.owner; repo; pull_number } } in
+    Openapi.Request.make
+      ~body:(Body.to_yojson body)
+      ~headers:[]
+      ~url_params:[]
+      ~query_params:[]
+      ~url
+      ~responses:
+        [
+          ("200", Openapi.of_json_body (fun r -> `OK r) Resp.of_yojson);
+          ("404", fun _ -> Ok `Not_found);
+        ]
+      `Post
+  in
+  (* A GraphQL error comes back as a 200 with an [errors] array, so it has to be
+     pulled apart rather than relying on the status code. *)
+  let decision = function
+    | { Resp.errors = Some (_ :: _ as errs); _ } ->
+        Abb.Future.return
+          (Error (`Graphql_err (CCList.map (fun { Resp.Err.message } -> message) errs)))
+    | {
+        Resp.data =
+          Some
+            {
+              Resp.Data.repository =
+                Some { Resp.Repository.pull_request = Some { Resp.Pull_request.review_decision } };
+            };
+        _;
+      } -> Abb.Future.return (Ok review_decision)
+    | _ -> Abb.Future.return (Error `Not_found)
+  in
+  let url = "/graphql" in
+  let request = create_review_decision_request url in
+  call client request
+  >>= fun resp ->
+  match Openapi.Response.value resp with
+  | `OK resp -> decision resp
+  | `Not_found -> (
+      let url = "/api/graphql" in
+      let request = create_review_decision_request url in
+      call client request
+      >>= fun resp ->
+      match Openapi.Response.value resp with
+      | `OK resp -> decision resp
+      | `Not_found -> Abb.Future.return (Error `Not_found))
 
 let react_to_comment ?(content = `Rocket) ~owner ~repo ~comment_id client =
   Prmths.Counter.inc_one (Metrics.fn_call_total "react_to_comment");

--- a/code/src/terrat_github/terrat_github.mli
+++ b/code/src/terrat_github/terrat_github.mli
@@ -91,6 +91,13 @@ type minimize_comment_err =
   ]
 [@@deriving show]
 
+type fetch_pull_request_review_decision_err =
+  [ Githubc2_abb.call_err
+  | `Graphql_err of string list
+  | `Not_found
+  ]
+[@@deriving show]
+
 type publish_reaction_err =
   [ Githubc2_abb.call_err
   | `Unprocessable_entity of Githubc2_components.Validation_error.t
@@ -296,6 +303,16 @@ val minimize_comment :
   comment_id:int ->
   Githubc2_abb.t ->
   (unit, [> minimize_comment_err ]) result Abb.Future.t
+
+(** GitHub's [PullRequest.reviewDecision], which is its own verdict on the target branch's
+    required-review rule, CODEOWNERS included. [None] means GitHub returned [null], which happens
+    when the branch requires no reviews at all. *)
+val fetch_pull_request_review_decision :
+  owner:string ->
+  repo:string ->
+  pull_number:int ->
+  Githubc2_abb.t ->
+  (string option, [> fetch_pull_request_review_decision_err ]) result Abb.Future.t
 
 val react_to_comment :
   ?content:Githubc2_reactions.Create_for_issue_comment.Request_body.Primary.Content.t ->

--- a/code/src/terrat_pull_request/terrat_pull_request_review.ml
+++ b/code/src/terrat_pull_request/terrat_pull_request_review.ml
@@ -5,6 +5,17 @@ module Status = struct
   [@@deriving show, eq]
 end
 
+(* The VCS's own verdict on whether the pull request satisfies the required
+   reviews for the branch it targets, which is a different question than whether
+   any individual review has been approved. *)
+module Decision = struct
+  type t =
+    | Approved
+    | Changes_requested
+    | Review_required
+  [@@deriving show, eq]
+end
+
 type t = {
   id : string;
   status : Status.t;

--- a/code/src/terrat_pull_request/terrat_pull_request_review.mli
+++ b/code/src/terrat_pull_request/terrat_pull_request_review.mli
@@ -5,6 +5,14 @@ module Status : sig
 end
 [@@deriving show, eq]
 
+module Decision : sig
+  type t =
+    | Approved
+    | Changes_requested
+    | Review_required
+  [@@deriving show, eq]
+end
+
 type t = {
   id : string;
   status : Status.t;

--- a/code/src/terrat_vcs_api/terrat_vcs_api.ml
+++ b/code/src/terrat_vcs_api/terrat_vcs_api.ml
@@ -180,6 +180,16 @@ module type S = sig
     Client.t ->
     (Terrat_base_repo_config_v1.Access_control.Match.t list, [> `Error ]) result Abb.Future.t
 
+  (** The VCS's verdict on the pull request's required reviews. [None] means the VCS has no verdict,
+      either because the target branch requires no reviews or because the VCS does not implement
+      this. *)
+  val fetch_pull_request_review_decision :
+    request_id:string ->
+    Repo.t ->
+    Pull_request.Id.t ->
+    Client.t ->
+    (Terrat_pull_request_review.Decision.t option, [> `Error ]) result Abb.Future.t
+
   val fetch_diff_files :
     request_id:string ->
     base_ref:Ref.t ->

--- a/code/src/terrat_vcs_api_github/terrat_vcs_api_github.ml
+++ b/code/src/terrat_vcs_api_github/terrat_vcs_api_github.ml
@@ -797,6 +797,36 @@ let fetch_pull_request_requested_reviews ~request_id repo pull_number client =
           m "%s : FETCH_PULL_REQUEST_REQUESTED_REVIEWS: %a" request_id Githubc2_abb.pp_call_err err);
       Abb.Future.return (Error `Error)
 
+let fetch_pull_request_review_decision ~request_id repo pull_number client =
+  let module D = Terrat_pull_request_review.Decision in
+  let open Abb.Future.Infix_monad in
+  Terrat_github.fetch_pull_request_review_decision
+    ~owner:repo.Repo.owner
+    ~repo:repo.Repo.name
+    ~pull_number
+    client.Client.client
+  >>= function
+  | Ok None -> Abb.Future.return (Ok None)
+  | Ok (Some "APPROVED") -> Abb.Future.return (Ok (Some D.Approved))
+  | Ok (Some "CHANGES_REQUESTED") -> Abb.Future.return (Ok (Some D.Changes_requested))
+  | Ok (Some "REVIEW_REQUIRED") -> Abb.Future.return (Ok (Some D.Review_required))
+  | Ok (Some decision) ->
+      (* A value outside the documented enum means GitHub changed the API under
+         us.  Erroring is safer than guessing which way it should resolve. *)
+      Prmths.Counter.inc_one Metrics.github_errors_total;
+      Logs.err (fun m ->
+          m "%s : FETCH_PULL_REQUEST_REVIEW_DECISION : UNKNOWN : %s" request_id decision);
+      Abb.Future.return (Error `Error)
+  | Error (#Terrat_github.fetch_pull_request_review_decision_err as err) ->
+      Prmths.Counter.inc_one Metrics.github_errors_total;
+      Logs.err (fun m ->
+          m
+            "%s : FETCH_PULL_REQUEST_REVIEW_DECISION : %a"
+            request_id
+            Terrat_github.pp_fetch_pull_request_review_decision_err
+            err);
+      Abb.Future.return (Error `Error)
+
 let merge_pull_request' ?(retain_pr_title = false) request_id client pull_request merge_strategy =
   let open Abbs_future_combinators.Infix_result_monad in
   let module Ms = Terrat_base_repo_config_v1.Automerge.Merge_strategy in

--- a/code/src/terrat_vcs_api_gitlab/terrat_vcs_api_gitlab.ml
+++ b/code/src/terrat_vcs_api_gitlab/terrat_vcs_api_gitlab.ml
@@ -961,6 +961,10 @@ let fetch_pull_request_requested_reviews ~request_id repo pull_number client =
           m "%s : FETCH_PULL_REQUEST_REQUESTED_REVIEWS : %a" request_id Openapic_abb.pp_call_err err);
       Abb.Future.return (Error `Error)
 
+(* GitLab has no equivalent of GitHub's [reviewDecision], so there is no verdict
+   to report and [require_completed_reviews] keeps using requested reviewers. *)
+let fetch_pull_request_review_decision ~request_id:_ _ _ _ = Abb.Future.return (Ok None)
+
 let merge_pull_request ~request_id ?(retain_pr_title = false) client pull_request merge_strategy =
   let module Gl =
     Gitlabc_projects_merge_requests.PutApiV4ProjectsIdMergeRequestsMergeRequestIidMerge

--- a/code/src/terrat_vcs_api_nyi/terrat_vcs_api_nyi.ml
+++ b/code/src/terrat_vcs_api_nyi/terrat_vcs_api_nyi.ml
@@ -127,6 +127,7 @@ let create_commit_checks ~request_id client repo ref_ checks = raise (Failure "n
 let fetch_commit_checks ~request_id client repo ref_ = raise (Failure "nyi")
 let fetch_pull_request_reviews ~request_id client repo pull_request = raise (Failure "nyi")
 let fetch_pull_request_requested_reviews ~request_id repo pull_number client = raise (Failure "nyi")
+let fetch_pull_request_review_decision ~request_id repo pull_number client = raise (Failure "nyi")
 
 let merge_pull_request ~request_id ?retain_pr_title client pull_request merge_strategy =
   raise (Failure "nyi")

--- a/code/src/terrat_vcs_service_github/terrat_vcs_service_github_provider.ml
+++ b/code/src/terrat_vcs_service_github/terrat_vcs_service_github_provider.ml
@@ -2310,7 +2310,14 @@ module Apply_requirements = struct
         (* Abb.Future.return (Error (`Invalid_query query)) *))
     | M.Any -> Abb.Future.return (Ok true)
 
-  let compute_approved ~request_id client repo approved approved_reviews requested_reviews =
+  let compute_approved
+      ~request_id
+      client
+      repo
+      approved
+      approved_reviews
+      requested_reviews
+      review_decision =
     let module Match_set = CCSet.Make (Terrat_base_repo_config_v1.Access_control.Match) in
     let module Match_map = CCMap.Make (Terrat_base_repo_config_v1.Access_control.Match) in
     let open Abbs_future_combinators.Infix_result_monad in
@@ -2359,11 +2366,25 @@ module Apply_requirements = struct
          else any_of_count - CCList.length any_of_results)
     in
     let any_of_passed = missing_any_of = 0 in
+    (* GitHub's [reviewDecision] already accounts for CODEOWNERS, including that
+       an approval from any one owner of a path satisfies that path.  Prefer it
+       over the requested reviewers, which only say who has an outstanding
+       request and so keep reporting a second owner as missing long after
+       GitHub considers the pull request approved.  [reviewDecision] is [None]
+       when the target branch requires no reviews at all, in which case there is
+       no verdict to defer to and the requested reviewers are all we have. *)
     let required_reviews_passed =
-      (not require_completed_reviews) || CCList.is_empty requested_reviews
+      let module D = Terrat_pull_request_review.Decision in
+      (not require_completed_reviews)
+      ||
+      match review_decision with
+      | Some D.Approved -> true
+      | Some (D.Changes_requested | D.Review_required) -> false
+      | None -> CCList.is_empty requested_reviews
     in
     let missing_reviews =
-      all_of_missing @ if require_completed_reviews then requested_reviews else []
+      all_of_missing
+      @ if require_completed_reviews && not required_reviews_passed then requested_reviews else []
     in
     Logs.info (fun m ->
         m
@@ -2416,8 +2437,16 @@ module Apply_requirements = struct
         commit_checks
     in
     let { Ar.checks; _ } = R.apply_requirements repo_config in
+    (* Only worth an extra API call if some check actually asks for it. *)
+    let requires_review_decision =
+      CCList.exists
+        (fun { Abc.approved = { Ar.Approved.enabled; require_completed_reviews; _ }; _ } ->
+          enabled && require_completed_reviews)
+        checks
+    in
     Abbs_future_combinators.Infix_result_app.(
-      (fun reviews commit_checks requested_reviews -> (reviews, commit_checks, requested_reviews))
+      (fun reviews commit_checks requested_reviews review_decision ->
+        (reviews, commit_checks, requested_reviews, review_decision))
       <$> Abbs_time_it.run (log_time request_id "FETCH_APPROVED_TIME") (fun () ->
           Api.fetch_pull_request_reviews
             ~request_id
@@ -2435,8 +2464,16 @@ module Apply_requirements = struct
             ~request_id
             (Api.Pull_request.repo pull_request)
             (Api.Pull_request.id pull_request)
-            client))
-    >>= fun (reviews, commit_checks, requested_reviews) ->
+            client)
+      <*> Abbs_time_it.run (log_time request_id "FETCH_REVIEW_DECISION") (fun () ->
+          if requires_review_decision then
+            Api.fetch_pull_request_review_decision
+              ~request_id
+              (Api.Pull_request.repo pull_request)
+              (Api.Pull_request.id pull_request)
+              client
+          else Abb.Future.return (Ok None)))
+    >>= fun (reviews, commit_checks, requested_reviews, review_decision) ->
     let approved_reviews =
       CCList.filter
         (function
@@ -2482,6 +2519,7 @@ module Apply_requirements = struct
                   approved
                   approved_reviews
                   requested_reviews
+                  review_decision
                 >>= fun (approved_result, missing_reviews, missing_any_of_count, any_of_count) ->
                 let module Ac = Terrat_base_repo_config_v1.Apply_requirements.Approved in
                 let { Ac.any_of; _ } = approved in

--- a/docs/src/content/docs/configuration/access-control/codeowners.mdx
+++ b/docs/src/content/docs/configuration/access-control/codeowners.mdx
@@ -29,9 +29,11 @@ apply_requirements:
 ```
 
 With this configuration:
-- Terrateam will check that all CODEOWNERS have approved the pull request
-- If any required CODEOWNERS review is pending or has requested changes, the apply will be blocked
-- The apply can only proceed once all CODEOWNERS have approved
+- Terrateam will check that your VCS considers the pull request approved
+- If a required CODEOWNERS review is still pending or has requested changes, the apply will be blocked
+- The apply can proceed as soon as the CODEOWNERS requirement is satisfied
+
+Terrateam does not parse CODEOWNERS itself. It reads your VCS's own review verdict for the pull request, which means the apply gate matches the merge gate exactly. In particular, when a path lists more than one owner, [an approval from any one of them](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners) satisfies both. You never need to restate your CODEOWNERS file in `.terrateam/config.yml`.
 
 ### Environment-Specific CODEOWNERS Enforcement
 
@@ -69,10 +71,20 @@ When `require_completed_reviews: true` is configured:
 
 3. When someone runs `terrateam apply`, Terrateam checks:
    - Whether approval is required based on your configuration
-   - If all CODEOWNERS have approved the pull request
-   - If any required reviews are still pending or have requested changes
+   - Whether your VCS reports the pull request as approved
 
-4. If all CODEOWNERS have approved, the apply proceeds
+4. If the VCS reports the pull request as approved, the apply proceeds
 
-5. If any CODEOWNERS review is incomplete or has requested changes, Terrateam blocks the apply with a message indicating which reviews are still needed
+5. Otherwise Terrateam blocks the apply, listing any reviews that are still outstanding
 </Steps>
+
+## Requirements
+
+For the VCS verdict to account for code owners, the branch the pull request targets must have a branch protection rule or ruleset with **Require review from Code Owners** enabled. Without it, CODEOWNERS still auto-requests reviewers, but the VCS does not treat their approval as mandatory, and neither does Terrateam.
+
+Two cases behave differently:
+
+- **The branch requires reviews, but not from code owners.** The verdict counts approvals without regard to who gave them, so `require_completed_reviews` enforces the approval count rather than ownership.
+- **The branch requires no reviews at all.** There is no verdict to read. Terrateam falls back to requiring that no review request on the pull request is still outstanding.
+
+GitLab exposes no equivalent verdict, so on GitLab `require_completed_reviews` always uses the outstanding-review-request behavior.

--- a/docs/src/content/docs/reference/configuration/apply-requirements.mdx
+++ b/docs/src/content/docs/reference/configuration/apply-requirements.mdx
@@ -66,7 +66,7 @@ By adjusting these settings, you can customize the apply requirements to match y
 `require_completed_reviews` is an Enterprise Edition feature. It is included in [Hosted SaaS](https://terrateam.io) and self-hosted Enterprise deployments. Setting it to `true` on the Open Source Edition is not permitted — Terrateam rejects the configuration and posts a comment on the pull request. See [Editions](/editions/).
 :::
 
-When `require_completed_reviews: true`, Terrateam blocks `apply` until every reviewer that the VCS marks as required — including CODEOWNERS — has approved the pull request. Use this to enforce CODEOWNERS as a hard gate on the apply step rather than only on merge.
+When `require_completed_reviews: true`, Terrateam blocks `apply` until GitHub itself reports the pull request as approved. Use this to enforce CODEOWNERS as a hard gate on the apply step rather than only on merge.
 
 ```yaml
 apply_requirements:
@@ -76,6 +76,15 @@ apply_requirements:
         enabled: true
         require_completed_reviews: true
 ```
+
+Terrateam does not parse CODEOWNERS. It reads GitHub's own review verdict for the pull request, so the apply gate agrees exactly with GitHub's merge gate — including the rule that [an approval from any one owner of a path satisfies that path](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners). When two teams own the same file, one approval is enough for both GitHub and Terrateam. Nothing in `.terrateam/config.yml` needs to mirror your CODEOWNERS file, and edits to CODEOWNERS take effect immediately.
+
+For the verdict to reflect code owners, the target branch must have a branch protection rule or ruleset with **Require review from Code Owners** enabled. Two cases behave differently:
+
+- **The branch requires reviews, but not from code owners.** GitHub's verdict only counts approvals and ignores who gave them, so `require_completed_reviews` enforces the approval count rather than ownership.
+- **The branch requires no reviews at all.** GitHub has no verdict to give. Terrateam falls back to requiring that no review request on the pull request is still outstanding.
+
+On GitLab, `require_completed_reviews` always uses the outstanding-review-request behavior, as GitLab exposes no equivalent verdict.
 
 For full guidance, scoped examples, and how this interacts with CODEOWNERS files, see the [CODEOWNERS enforcement guide](/configuration/access-control/codeowners).
 


### PR DESCRIPTION
## Description

Closes #1436

`require_completed_reviews` is documented as CODEOWNERS enforcement but never read CODEOWNERS. It listed the pull request's requested reviewers and passed only when that list was empty.

That breaks when a path has more than one code owner. GitHub requests review from every owner, an approval from any one of them satisfies the requirement, and GitHub does not withdraw the other requests. Terrateam kept reporting those owners as missing and blocked applies GitHub considered approved.

This reads GitHub's own verdict instead — `PullRequest.reviewDecision`, which already has CODEOWNERS matching applied. No new config key; only the implementation changes. There is no REST equivalent, so it goes through GraphQL, following `minimize_comment` for the `/graphql` → `/api/graphql` fallback GHES needs. The call is skipped unless a check enables the requirement.

`reviewDecision` is null when the target branch requires no reviews. Failing closed there would block applies in repos without branch protection, so that case falls back to the old requested-reviewers check. GitLab has no equivalent field and keeps the old behavior.

## Type of change

- [x] Bug fix
- [ ] New feature
- [x] Breaking change
- [x] Documentation update
- [ ] Other (explain):

Two behavior changes:

1. Manually requested reviewers who are not code owners no longer block an apply once GitHub reports `APPROVED`. This is the intended fix.
2. A repo with required approving reviews but **Require review from Code Owners** disabled gets a `reviewDecision` that only counts approvals, ignoring owner identity, so `require_completed_reviews` is weaker than before for those repos.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/terrateamio/terrateam/blob/main/CONTRIBUTING.md)
- [x] The pull request title follows this format:
      `ISSUE_NUMBER ACTION_TYPE Short description` (e.g., `123 ADD Feature description`)
- [ ] I have added tests and documentation (if applicable)
- [ ] My changes generate no new warnings/errors and do not break existing functionality

Docs updated, no tests added. Not yet run against a live repository.