### PR TITLE
1442 FIX Link to the correct Actions run URL when a run fails

### DIFF
--- a/code/src/terrat_vcs_github_comment_templates/tmpl/work_manifest_run_failed.tmpl
+++ b/code/src/terrat_vcs_github_comment_templates/tmpl/work_manifest_run_failed.tmpl
@@ -1,5 +1,5 @@
 The GitHub Action for this Terrateam operation failed (run id `{{ run_id }}`).
 
-Open the [Actions tab](../../actions/runs/{{ run_id }}) in this repository to investigate the workflow run.
+Open the [Actions tab](../actions/runs/{{ run_id }}) in this repository to investigate the workflow run.
 
 If you need help, reach out to support@terrateam.io or ping us on [Slack](https://terrateam.io/slack).


### PR DESCRIPTION
## Description

Fixes #1442.

When a Terrateam Actions run fails we post a comment linking to the run. The link is relative and went one level too far up, so the browser resolved it against the pull request page path `/{owner}/{repo}/pull/{n}` and stripped both `pull` and the repository name, landing on `/{owner}/actions/runs/{run_id}`, which 404s. Go up one level instead of two.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (explain):

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/terrateamio/terrateam/blob/main/CONTRIBUTING.md)
- [x] The pull request title follows this format: `ISSUE_NUMBER ACTION_TYPE Short description` (e.g., `123 ADD Feature description`)
- [ ] I have added tests and documentation (if applicable)
- [x] My changes generate no new warnings/errors and do not break existing functionality